### PR TITLE
HP-23 : OAuth2 로그인

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
+    implementation("com.auth0:java-jwt:4.5.0")
 
     runtimeOnly("org.postgresql:postgresql")
 

--- a/src/main/java/com/happypill/api/config/SecurityConfig.java
+++ b/src/main/java/com/happypill/api/config/SecurityConfig.java
@@ -1,12 +1,16 @@
 package com.happypill.api.config;
 
+import com.happypill.api.oauth2.CustomOAuth2UserService;
+import com.happypill.api.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -17,10 +21,14 @@ import java.util.List;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 @Configuration
+@Profile("!test")
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final OAuth2SuccessHandler oauth2SuccessHandler;
+    private final CustomOAuth2UserService oauth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -31,6 +39,14 @@ public class SecurityConfig {
 
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(STATELESS))
+
+                .oauth2Login(o -> o
+                        .userInfoEndpoint(u -> u
+                                .userService(oauth2UserService)
+                                .oidcUserService(req -> (OidcUser) oauth2UserService.loadUser(req))
+                        )
+                        .successHandler(oauth2SuccessHandler)
+                )
 
                 .authorizeHttpRequests(authorize ->
                         authorize.anyRequest().permitAll()

--- a/src/main/java/com/happypill/api/controller/test/OAuth2TestController.java
+++ b/src/main/java/com/happypill/api/controller/test/OAuth2TestController.java
@@ -1,0 +1,67 @@
+package com.happypill.api.controller.test;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 개발용 임시 redirect
+ */
+@RestController
+public class OAuth2TestController {
+
+    /**
+     * Vercel 등으로 배포된 프로덕션 프론트엔드 URL
+     */
+    @Value("${app.frontend.base-url}")
+    private String baseUrl;
+
+    /**
+     * 프론트엔드 로그인 후 진입 경로 (예: "/login/callback")
+     */
+    @Value("${app.frontend.login-path:}")
+    private String loginPath;
+
+    /**
+     * 예: GET /?accessToken=...&refreshToken=...
+     */
+    @GetMapping(value = "/oauth2-test", produces = MediaType.TEXT_HTML_VALUE)
+    public String renderLinks(
+            @RequestParam String accessToken,
+            @RequestParam String refreshToken) {
+
+        // 로컬 프론트엔드 URL
+        String localUrl = "http://localhost:5173" + loginPath
+                + "?accessToken=" + accessToken
+                + "&refreshToken=" + refreshToken;
+
+        // 프로덕션 프론트엔드 URL
+        String prodUrl = baseUrl + loginPath
+                + "?accessToken=" + accessToken
+                + "&refreshToken=" + refreshToken;
+
+        return """
+                <!DOCTYPE html>
+                <html lang="en">
+                <head>
+                    <meta charset="UTF-8"/>
+                    <title>OAuth2 Debug Callback</title>
+                </head>
+                <body>
+                    <h1>디버깅용 OAuth2 콜백 페이지</h1>
+                    <p>accessToken: %s</p>
+                    <p>refreshToken: %s</p>
+                    <p><a href="%s">로컬 프론트엔드로 이동</a></p>
+                    <p><a href="%s">프로덕션 프론트엔드로 이동</a></p>
+                </body>
+                </html>
+                """.formatted(
+                accessToken,
+                refreshToken,
+                localUrl,
+                prodUrl
+        );
+    }
+}

--- a/src/main/java/com/happypill/api/controller/test/TestController.java
+++ b/src/main/java/com/happypill/api/controller/test/TestController.java
@@ -1,4 +1,4 @@
-package com.happypill.api.controller;
+package com.happypill.api.controller.test;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,11 +15,6 @@ public class TestController {
     @GetMapping("/health")
     public void healthCheck() {
 
-    }
-
-    @GetMapping("/")
-    public String hello() {
-        return "Hello!!!";
     }
 
     @GetMapping("/started-at")

--- a/src/main/java/com/happypill/api/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/happypill/api/oauth2/CustomOAuth2UserService.java
@@ -28,7 +28,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        log.info("userRequest = {}", userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
         OAuth2User oAuth2User = (userRequest instanceof OidcUserRequest oidcReq)

--- a/src/main/java/com/happypill/api/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/happypill/api/oauth2/CustomOAuth2UserService.java
@@ -22,7 +22,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     //로그인 확장시 사용
     private final OidcUserService oidcDelegate = new OidcUserService();
-//    private final DefaultOAuth2UserService oauth2Delegate = new DefaultOAuth2UserService();
+    private final DefaultOAuth2UserService oauth2Delegate = new DefaultOAuth2UserService();
 
     private final List<OAuth2UserProvisionStrategy> provisionStrategies;
 
@@ -32,7 +32,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         OAuth2User oAuth2User = (userRequest instanceof OidcUserRequest oidcReq)
                 ? oidcDelegate.loadUser(oidcReq)
-                : new DefaultOAuth2UserService().loadUser(userRequest);
+                : oauth2Delegate.loadUser(userRequest);
         try {
             HappypillUser user = provisionStrategies
                     .stream()

--- a/src/main/java/com/happypill/api/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/happypill/api/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,51 @@
+package com.happypill.api.oauth2;
+
+import com.happypill.api.oauth2.userprovision.OAuth2UserProvisionStrategy;
+import com.happypill.application.entity.HappypillUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    //로그인 확장시 사용
+    private final OidcUserService oidcDelegate = new OidcUserService();
+//    private final DefaultOAuth2UserService oauth2Delegate = new DefaultOAuth2UserService();
+
+    private final List<OAuth2UserProvisionStrategy> provisionStrategies;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("userRequest = {}", userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2User oAuth2User = (userRequest instanceof OidcUserRequest oidcReq)
+                ? oidcDelegate.loadUser(oidcReq)
+                : new DefaultOAuth2UserService().loadUser(userRequest);
+        try {
+            HappypillUser user = provisionStrategies
+                    .stream()
+                    .filter(st -> st.supports(registrationId))
+                    .findFirst()
+                    .orElseThrow(() -> new RuntimeException("cannot find provider"))
+                    .provision(oAuth2User);
+            return OAuth2UserPrincipal.of(user.getUserId(), user.getLoginEmail(), List.of(user.getRole()));
+        } catch (RuntimeException e) {
+            log.error("OAuth2 user provision failed for provider: {}", registrationId, e);
+            throw new OAuth2AuthenticationException(e.getMessage());
+        }
+
+    }
+}

--- a/src/main/java/com/happypill/api/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/happypill/api/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,38 @@
+package com.happypill.api.oauth2;
+
+import com.happypill.application.auth.jwt.JwtService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtService jwtService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2UserPrincipal principal = (OAuth2UserPrincipal) authentication.getPrincipal();
+
+        String accessToken = jwtService.generateAccessToken(principal.getId(), principal.getRoleNames());
+        String refreshToken = UUID.randomUUID().toString();
+
+        //TODO refreshToken 전략
+        String redirectUrl = UriComponentsBuilder
+                .fromPath("/oauth2-test")
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build()
+                .toUriString();
+
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/com/happypill/api/oauth2/OAuth2UserPrincipal.java
+++ b/src/main/java/com/happypill/api/oauth2/OAuth2UserPrincipal.java
@@ -1,0 +1,70 @@
+package com.happypill.api.oauth2;
+
+import com.happypill.application.entity.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor(access = PRIVATE)
+public class OAuth2UserPrincipal implements OidcUser, OAuth2User {
+
+    private final Long id;
+    private final String email;
+    private final List<Role> roles;
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> claims;
+
+    public static OAuth2UserPrincipal of(Long id, String email, List<Role> roles) {
+        return new OAuth2UserPrincipal(id, email, roles, null, null);
+    }
+
+    public String[] getRoleNames() {
+        return roles.stream()
+                .map(Role::name)
+                .toArray(String[]::new);
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return claims;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles.stream()
+                .map(r -> new SimpleGrantedAuthority(r.name()))
+                .toList();
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return null;
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return null;
+    }
+}

--- a/src/main/java/com/happypill/api/oauth2/userprovision/GoogleProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/oauth2/userprovision/GoogleProvisionStrategy.java
@@ -3,12 +3,17 @@ package com.happypill.api.oauth2.userprovision;
 import com.happypill.application.entity.HappypillUser;
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
+import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import com.happypill.application.util.SnowflakeUtil;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GoogleProvisionStrategy extends OAuth2UserProvisionStrategy {
+    
+    public GoogleProvisionStrategy(HappypillUserRepository repository) {
+        super(repository);
+    }
 
     @Override
     protected String extractSub(OAuth2User oAuth2User) {

--- a/src/main/java/com/happypill/api/oauth2/userprovision/GoogleProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/oauth2/userprovision/GoogleProvisionStrategy.java
@@ -1,0 +1,29 @@
+package com.happypill.api.oauth2.userprovision;
+
+import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.entity.enums.Provider;
+import com.happypill.application.entity.enums.Role;
+import com.happypill.application.util.SnowflakeUtil;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleProvisionStrategy extends OAuth2UserProvisionStrategy {
+
+    @Override
+    protected String extractSub(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute("sub");
+    }
+
+    @Override
+    public boolean supports(String provider) {
+        return provider.equalsIgnoreCase(Provider.GOOGLE.name());
+    }
+
+    @Override
+    protected HappypillUser createUser(OAuth2User oAuth2User) {
+        String sub = oAuth2User.getAttribute("sub");
+        String email = oAuth2User.getAttribute("email");
+        return HappypillUser.ofSocial(SnowflakeUtil.nextId(), null, Provider.GOOGLE, sub, email, Role.USER);
+    }
+}

--- a/src/main/java/com/happypill/api/oauth2/userprovision/KakaoProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/oauth2/userprovision/KakaoProvisionStrategy.java
@@ -3,12 +3,18 @@ package com.happypill.api.oauth2.userprovision;
 import com.happypill.application.entity.HappypillUser;
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
+import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import com.happypill.application.util.SnowflakeUtil;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KakaoProvisionStrategy extends OAuth2UserProvisionStrategy {
+
+    public KakaoProvisionStrategy(HappypillUserRepository repository) {
+        super(repository);
+    }
+
     @Override
     protected String extractSub(OAuth2User oAuth2User) {
         return oAuth2User.getAttribute("sub");

--- a/src/main/java/com/happypill/api/oauth2/userprovision/KakaoProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/oauth2/userprovision/KakaoProvisionStrategy.java
@@ -1,0 +1,28 @@
+package com.happypill.api.oauth2.userprovision;
+
+import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.entity.enums.Provider;
+import com.happypill.application.entity.enums.Role;
+import com.happypill.application.util.SnowflakeUtil;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoProvisionStrategy extends OAuth2UserProvisionStrategy {
+    @Override
+    protected String extractSub(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute("sub");
+    }
+
+    @Override
+    public boolean supports(String provider) {
+        return provider.equalsIgnoreCase(Provider.KAKAO.name());
+    }
+
+    @Override
+    protected HappypillUser createUser(OAuth2User oAuth2User) {
+        String sub = oAuth2User.getAttribute("sub");
+        String email = oAuth2User.getAttribute("email");
+        return HappypillUser.ofSocial(SnowflakeUtil.nextId(), null, Provider.KAKAO, sub, email, Role.USER);
+    }
+}

--- a/src/main/java/com/happypill/api/oauth2/userprovision/OAuth2UserProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/oauth2/userprovision/OAuth2UserProvisionStrategy.java
@@ -2,13 +2,13 @@ package com.happypill.api.oauth2.userprovision;
 
 import com.happypill.application.entity.HappypillUser;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+@RequiredArgsConstructor
 public abstract class OAuth2UserProvisionStrategy {
 
-    @Autowired
-    protected HappypillUserRepository repository;
+    private final HappypillUserRepository repository;
 
     public HappypillUser provision(OAuth2User oAuth2User) {
         String sub = extractSub(oAuth2User);

--- a/src/main/java/com/happypill/api/oauth2/userprovision/OAuth2UserProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/oauth2/userprovision/OAuth2UserProvisionStrategy.java
@@ -1,0 +1,28 @@
+package com.happypill.api.oauth2.userprovision;
+
+import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public abstract class OAuth2UserProvisionStrategy {
+
+    @Autowired
+    protected HappypillUserRepository repository;
+
+    public HappypillUser provision(OAuth2User oAuth2User) {
+        String sub = extractSub(oAuth2User);
+        if (sub == null) {
+            throw new RuntimeException("sub cannot be null");
+        }
+        return repository.findBySocialSub(sub)
+                .orElseGet(() -> repository.save(createUser(oAuth2User)));
+    }
+
+    protected abstract String extractSub(OAuth2User oAuth2User);
+
+
+    public abstract boolean supports(String provider);
+
+    protected abstract HappypillUser createUser(OAuth2User oAuth2User);
+}

--- a/src/main/java/com/happypill/application/auth/jwt/JwtConfig.java
+++ b/src/main/java/com/happypill/application/auth/jwt/JwtConfig.java
@@ -1,0 +1,19 @@
+package com.happypill.application.auth.jwt;
+
+import com.auth0.jwt.algorithms.Algorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
+@RequiredArgsConstructor
+public class JwtConfig {
+    private final JwtProperties jwtProperties;
+
+    @Bean
+    public Algorithm algorithm() {
+        return Algorithm.HMAC256(jwtProperties.getSecretKey());
+    }
+}

--- a/src/main/java/com/happypill/application/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/happypill/application/auth/jwt/JwtProperties.java
@@ -1,0 +1,15 @@
+package com.happypill.application.auth.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    private String issuer;
+    private String secretKey;
+    private Integer accessTokenTTLSeconds;
+    private Integer refreshTokenTTLSeconds;
+}

--- a/src/main/java/com/happypill/application/auth/jwt/JwtService.java
+++ b/src/main/java/com/happypill/application/auth/jwt/JwtService.java
@@ -1,0 +1,33 @@
+package com.happypill.application.auth.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtProperties jwtProperties;
+    private final Algorithm algorithm;
+
+    public String generateAccessToken(@NonNull Long id, String[] roles) {
+        return JWT.create()
+                .withSubject(String.valueOf(id))
+                .withIssuer(jwtProperties.getIssuer())
+                .withIssuedAt(Instant.now())
+                .withExpiresAt(calculateExpiration(jwtProperties.getAccessTokenTTLSeconds()))
+                .withArrayClaim("roles", roles)
+                .sign(algorithm);
+    }
+
+
+    private Instant calculateExpiration(long ttlSeconds) {
+        return Instant.now().plusSeconds(ttlSeconds);
+    }
+
+}

--- a/src/main/java/com/happypill/application/entity/BaseEntity.java
+++ b/src/main/java/com/happypill/application/entity/BaseEntity.java
@@ -1,11 +1,7 @@
 package com.happypill.application.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
@@ -15,11 +11,20 @@ import java.time.ZonedDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
-    @CreatedDate
     @Column(name = "created_at", updatable = false, columnDefinition = "TIMESTAMPTZ")
     private ZonedDateTime createdAt;
 
-    @LastModifiedDate
     @Column(name = "updated_at", columnDefinition = "TIMESTAMPTZ")
     private ZonedDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = ZonedDateTime.now();
+        this.updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = ZonedDateTime.now();
+    }
 }

--- a/src/main/java/com/happypill/application/entity/BaseEntity.java
+++ b/src/main/java/com/happypill/application/entity/BaseEntity.java
@@ -1,14 +1,15 @@
 package com.happypill.application.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Getter;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
 
 @Getter
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
     @Column(name = "created_at", updatable = false, columnDefinition = "TIMESTAMPTZ")

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -2,18 +2,25 @@ package com.happypill.application.entity;
 
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
-import jakarta.persistence.*;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
 @Table(name = "happypill_users")
-public class HappypillUser extends BaseEntity{
+public class HappypillUser extends BaseEntity {
 
     @Id
     private Long userId;
@@ -23,10 +30,16 @@ public class HappypillUser extends BaseEntity{
     @Enumerated(STRING)
     private Provider provider;
 
+    private String socialSub;
+
     private String loginEmail;
 
     private boolean isDeleted;
 
     @Enumerated(STRING)
     private Role role;
+
+    public static HappypillUser ofSocial(@Nullable Long id, String nickName, Provider provider, String socialSub, String loginEmail, Role role) {
+        return new HappypillUser(id, nickName, provider, socialSub, loginEmail, false, role);
+    }
 }

--- a/src/main/java/com/happypill/application/repository/happypilluser/HappypillUserRepository.java
+++ b/src/main/java/com/happypill/application/repository/happypilluser/HappypillUserRepository.java
@@ -2,7 +2,13 @@ package com.happypill.application.repository.happypilluser;
 
 import com.happypill.application.entity.HappypillUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface HappypillUserRepository extends JpaRepository<HappypillUser, Long> {
 
+    @Query("SELECT u FROM HappypillUser u WHERE u.socialSub = :socialSub")
+    Optional<HappypillUser> findBySocialSub(@Param("socialSub") String socialSub);
 }

--- a/src/main/java/com/happypill/application/repository/happypilluser/HappypillUserRepository.java
+++ b/src/main/java/com/happypill/application/repository/happypilluser/HappypillUserRepository.java
@@ -2,13 +2,11 @@ package com.happypill.application.repository.happypilluser;
 
 import com.happypill.application.entity.HappypillUser;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface HappypillUserRepository extends JpaRepository<HappypillUser, Long> {
-
-    @Query("SELECT u FROM HappypillUser u WHERE u.socialSub = :socialSub")
+    
     Optional<HappypillUser> findBySocialSub(@Param("socialSub") String socialSub);
 }

--- a/src/main/java/com/happypill/application/util/SnowflakeUtil.java
+++ b/src/main/java/com/happypill/application/util/SnowflakeUtil.java
@@ -1,0 +1,63 @@
+package com.happypill.application.util;
+
+import java.util.random.RandomGenerator;
+
+public final class SnowflakeUtil {
+
+    private static final int NODE_ID_BITS    = 10;
+    private static final int SEQUENCE_BITS   = 12;
+
+    private static final long MAX_NODE_ID    = (1L << NODE_ID_BITS) - 1;
+    private static final long MAX_SEQUENCE   = (1L << SEQUENCE_BITS) - 1;
+
+    // UTC = 2024-01-01T00:00:00Z
+    private static final long START_TIME_MILLIS = 1704067200000L;
+
+    // JVM 시작 시 한 번만 결정되는 node ID
+    private static final long NODE_ID;
+
+    // 내부 상태
+    private static long lastTimeMillis = START_TIME_MILLIS;
+    private static long sequence       = 0L;
+
+    static {
+        // 환경변수나 설정 없이 랜덤 노드 ID 할당
+        NODE_ID = RandomGenerator.getDefault().nextLong(MAX_NODE_ID + 1);
+    }
+
+    private SnowflakeUtil() { /* 인스턴스 생성 금지 */ }
+
+    /**
+     * 다음 유일한 64-bit ID 생성
+     */
+    public static synchronized long nextId() {
+        long currentTime = System.currentTimeMillis();
+        if (currentTime < lastTimeMillis) {
+            throw new IllegalStateException(
+                    "Clock moved backwards. Refusing to generate id for " +
+                            (lastTimeMillis - currentTime) + " ms");
+        }
+        if (currentTime == lastTimeMillis) {
+            sequence = (sequence + 1) & MAX_SEQUENCE;
+            if (sequence == 0) {
+                currentTime = waitNextMillis(currentTime);
+            }
+        } else {
+            sequence = 0L;
+        }
+        lastTimeMillis = currentTime;
+
+        return ((currentTime - START_TIME_MILLIS) << (NODE_ID_BITS + SEQUENCE_BITS))
+                | (NODE_ID << SEQUENCE_BITS)
+                | sequence;
+    }
+
+    private static long waitNextMillis(long lastTs) {
+        long ts = System.currentTimeMillis();
+        while (ts <= lastTs) {
+            ts = System.currentTimeMillis();
+        }
+        return ts;
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,45 @@ spring:
   jpa:
     open-in-view: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope:
+              - openid
+              - profile
+              - email
+          kakao:
+            client-id: ${KAKAO_REST_API_KEY}
+            #            client-secret:
+            client-authentication-method: client_secret_post
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope:
+              - openid
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            #            user-name-attribute: id
+            issuer-uri: https://kauth.kakao.com
+
+jwt:
+  access-token-ttlSeconds: 600 #
+  refresh-token-ttlSeconds: 86400 # 60 * 60 * 24
+  secret-key: ${JWT_SECRET_KEY:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2W3x4Y5z6A7B8C9D0E1F2G3H4I5J6K7L8M9N0O1P2Q3R4S5T6U7V8W9X0Y1Z2a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8A9B0C1D2E3F4G5H6}
+  issuer: https://happypill-api.jiheon2234.dev
+
+app:
+  frontend:
+    base-url: https://happypill.jiheon2234.dev
+    login-path: ''
+
 
 --- # dev
 spring.config.activate.on-profile: dev

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OAuth2 Login Test</title>
+</head>
+<body>
+<h1>OAuth2 로그인 테스트</h1>
+
+<a href="/oauth2/authorization/google">
+    <button>Login with Google</button>
+</a>
+<br/><br/>
+
+<a href="/oauth2/authorization/kakao">
+    <button>Login with Kakao</button>
+</a>
+</body>
+</html>

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,21 @@ spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:postgresql:17:///testdb
+
+
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+
+app:
+  frontend:
+    base-url: https://happypill.jiheon2234.dev
+    login-path: ''
+
+
+jwt:
+  access-token-ttlSeconds: 300 # 60 * 5
+  refresh-token-ttlSeconds: 86400 # 60 * 5
+  secret-key: ${JWT_SECRET_KEY:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2W3x4Y5z6A7B8C9D0E1F2G3H4I5J6K7L8M9N0O1P2Q3R4S5T6U7V8W9X0Y1Z2a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8A9B0C1D2E3F4G5H6}
+  issuer: https://happypill-api.jiheon2234.dev


### PR DESCRIPTION
# 티켓
HP-23

# 설명
구글, 카카오 회원가입/로그인 후, accessToken과 refreshToken을 프론트엔드에 리다이렉트로 넘겨주기까지의 과정


## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
시큐리티 테스트 생략

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

@coderabbitai
이게될지모르겠네
jwt secret 노출이나, OAuth2TestController등의 보안 문제점은 개발단계이기 때문에 무시할 것
refreshToken 활용 전략이나, RuntimeException 사용 등은 아직 구체적으로 정해지지 않았기 때문에 무시할 것 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - OAuth2 로그인 후 JWT 액세스/리프레시 토큰이 발급되며, 테스트용 HTML 페이지에서 토큰 확인 및 프론트엔드 연동 링크를 제공합니다.
  - Google 및 Kakao OAuth2 소셜 로그인 지원이 추가되었습니다.
  - OAuth2 로그인 성공 후 토큰을 확인할 수 있는 테스트 페이지가 새로 제공됩니다.
- **버그 수정**
  - 엔티티의 생성 및 수정 시점 관리가 내부 메서드로 변경되어 일관성을 확보했습니다.
- **설정**
  - OAuth2 클라이언트 정보, JWT 토큰 TTL, 비밀키, 프론트엔드 URL 관련 설정이 application.yml 및 테스트 환경 파일에 추가되었습니다.
- **기타**
  - 소셜 사용자 식별 전략과 JWT 토큰 발급 로직이 도입되어 인증 흐름이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->