### PR TITLE
HP-54: 전체 카테고리 정보 획득 endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/happypill/api/controller/CategoryController.java
+++ b/src/main/java/com/happypill/api/controller/CategoryController.java
@@ -1,7 +1,6 @@
 package com.happypill.api.controller;
 
 import com.happypill.application.dto.response.CategoryResponse;
-import com.happypill.application.entity.enums.Language;
 import com.happypill.application.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,8 +15,8 @@ import java.util.Locale;
 @RequiredArgsConstructor
 @RequestMapping("/api/categories")
 public class CategoryController {
-    private final CategoryService categoryService;
     private static final String LANGUAGE_HEADER = "Language";
+    private final CategoryService categoryService;
 
     @GetMapping
     public List<CategoryResponse> getCategories(@RequestHeader(LANGUAGE_HEADER) String headerLanguage) {

--- a/src/main/java/com/happypill/api/controller/CategoryController.java
+++ b/src/main/java/com/happypill/api/controller/CategoryController.java
@@ -1,0 +1,25 @@
+package com.happypill.api.controller;
+
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.service.CategoryService;
+import com.happypill.application.dto.response.CategoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public List<CategoryResponse> getCategories(@RequestHeader("Language") String headerLanguage) {
+        Language language = Language.parseLanguage(headerLanguage);
+        return categoryService.getAllCategories(language);
+    }
+}

--- a/src/main/java/com/happypill/api/controller/CategoryController.java
+++ b/src/main/java/com/happypill/api/controller/CategoryController.java
@@ -1,8 +1,8 @@
 package com.happypill.api.controller;
 
+import com.happypill.application.dto.response.CategoryResponse;
 import com.happypill.application.entity.enums.Language;
 import com.happypill.application.service.CategoryService;
-import com.happypill.application.dto.response.CategoryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -10,16 +10,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Locale;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/categories")
 public class CategoryController {
     private final CategoryService categoryService;
+    private static final String LANGUAGE_HEADER = "Language";
 
     @GetMapping
-    public List<CategoryResponse> getCategories(@RequestHeader("Language") String headerLanguage) {
-        Language language = Language.parseLanguage(headerLanguage);
-        return categoryService.getAllCategories(language);
+    public List<CategoryResponse> getCategories(@RequestHeader(LANGUAGE_HEADER) String headerLanguage) {
+        Locale locale = Locale.of(headerLanguage);
+        return categoryService.getAllCategories(locale);
     }
 }

--- a/src/main/java/com/happypill/application/dto/response/CategoryResponse.java
+++ b/src/main/java/com/happypill/application/dto/response/CategoryResponse.java
@@ -7,9 +7,4 @@ public record CategoryResponse (
      String description,
      String bannerImgUrl
 ) {
-
-    public static CategoryResponse of(Long categoryId, String thumbnailUrl, String name,
-                                                       String description, String bannerImgUrl) {
-        return new CategoryResponse(categoryId, thumbnailUrl, name, description, bannerImgUrl);
-    }
 }

--- a/src/main/java/com/happypill/application/dto/response/CategoryResponse.java
+++ b/src/main/java/com/happypill/application/dto/response/CategoryResponse.java
@@ -1,0 +1,15 @@
+package com.happypill.application.dto.response;
+
+public record CategoryResponse (
+     Long categoryId,
+     String thumbnailUrl,
+     String name,
+     String description,
+     String bannerImgUrl
+) {
+
+    public static CategoryResponse of(Long categoryId, String thumbnailUrl, String name,
+                                                       String description, String bannerImgUrl) {
+        return new CategoryResponse(categoryId, thumbnailUrl, name, description, bannerImgUrl);
+    }
+}

--- a/src/main/java/com/happypill/application/entity/Category.java
+++ b/src/main/java/com/happypill/application/entity/Category.java
@@ -3,13 +3,16 @@ package com.happypill.application.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@AllArgsConstructor(access = PRIVATE)
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "categories")
 public class Category extends BaseEntity{
@@ -20,4 +23,8 @@ public class Category extends BaseEntity{
     private String thumbnailUrl;
 
     private String bannerUrl;
+
+    public static Category of(Long categoryId, String thumbnailUrl, String bannerUrl) {
+        return new Category(categoryId, thumbnailUrl, bannerUrl);
+    }
 }

--- a/src/main/java/com/happypill/application/entity/CategoryInfo.java
+++ b/src/main/java/com/happypill/application/entity/CategoryInfo.java
@@ -2,15 +2,18 @@ package com.happypill.application.entity;
 
 import com.happypill.application.entity.enums.Language;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@AllArgsConstructor(access = PRIVATE)
 @NoArgsConstructor(access = PROTECTED)
 @Table(name = "category_info")
 public class CategoryInfo extends BaseEntity{
@@ -28,4 +31,8 @@ public class CategoryInfo extends BaseEntity{
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    public static CategoryInfo of(Long categoryInfoId, Language language, String name, String description, Category category) {
+        return new CategoryInfo(categoryInfoId, language, name, description, category);
+    }
 }

--- a/src/main/java/com/happypill/application/entity/enums/Language.java
+++ b/src/main/java/com/happypill/application/entity/enums/Language.java
@@ -13,4 +13,12 @@ public enum Language {
     public String getDescription() {
         return description;
     }
+
+    public static Language parseLanguage(String language) {
+        try {
+            return Language.valueOf(language.toUpperCase());
+        } catch (Exception e) {
+            return Language.KO;
+        }
+    }
 }

--- a/src/main/java/com/happypill/application/entity/enums/Language.java
+++ b/src/main/java/com/happypill/application/entity/enums/Language.java
@@ -18,6 +18,7 @@ public enum Language {
         try {
             return Language.valueOf(language.toUpperCase());
         } catch (Exception e) {
+            // To do : KO를 business Exception 으로 변경할 것
             return Language.KO;
         }
     }

--- a/src/main/java/com/happypill/application/repository/categoryinfo/CategoryInfoRepository.java
+++ b/src/main/java/com/happypill/application/repository/categoryinfo/CategoryInfoRepository.java
@@ -1,7 +1,11 @@
 package com.happypill.application.repository.categoryinfo;
 
 import com.happypill.application.entity.CategoryInfo;
+import com.happypill.application.entity.enums.Language;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Long> {
+    List<CategoryInfo> findByLanguage(Language language);
 }

--- a/src/main/java/com/happypill/application/service/CategoryService.java
+++ b/src/main/java/com/happypill/application/service/CategoryService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +19,8 @@ import java.util.List;
 public class CategoryService {
     private final CategoryInfoRepository categoryInfoRepository;
 
-    public List<CategoryResponse> getAllCategories(Language language) {
+    public List<CategoryResponse> getAllCategories(Locale locale) {
+        Language language = Language.parseLanguage(locale.getLanguage());
         List<CategoryResponse> results = new ArrayList<>();
         List<CategoryInfo> categoryInfoList = categoryInfoRepository.findByLanguage(language);
         Category category = null;
@@ -26,7 +28,7 @@ public class CategoryService {
 
         for (CategoryInfo categoryInfo : categoryInfoList) {
             category = categoryInfo.getCategory();
-            response = CategoryResponse.of(category.getCategoryId(), category.getThumbnailUrl(),
+            response = new CategoryResponse(category.getCategoryId(), category.getThumbnailUrl(),
                     categoryInfo.getName(), categoryInfo.getDescription(), category.getBannerUrl());
             results.add(response);
         }

--- a/src/main/java/com/happypill/application/service/CategoryService.java
+++ b/src/main/java/com/happypill/application/service/CategoryService.java
@@ -1,0 +1,36 @@
+package com.happypill.application.service;
+
+import com.happypill.application.dto.response.CategoryResponse;
+import com.happypill.application.entity.Category;
+import com.happypill.application.entity.CategoryInfo;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CategoryService {
+    private final CategoryInfoRepository categoryInfoRepository;
+
+    public List<CategoryResponse> getAllCategories(Language language) {
+        List<CategoryResponse> results = new ArrayList<>();
+        List<CategoryInfo> categoryInfoList = categoryInfoRepository.findByLanguage(language);
+        Category category = null;
+        CategoryResponse response = null;
+
+        for (CategoryInfo categoryInfo : categoryInfoList) {
+            category = categoryInfo.getCategory();
+            response = CategoryResponse.of(category.getCategoryId(), category.getThumbnailUrl(),
+                    categoryInfo.getName(), categoryInfo.getDescription(), category.getBannerUrl());
+            results.add(response);
+        }
+
+        return results;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,11 +60,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-    show-sql: true
-    properties:
-      hibernate.hibernate.format_sql: true
-
-
 
 --- # prod
 spring.config.activate.on-profile: prod

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+insert into categories(category_id, banner_url, thumbnail_url)
+values (1, 'first_banner_url', 'first_thumbnail_url'), (2, 'second_banner_url', 'second_thumbnail_url')
+
+insert into category_info(category_id, category_info_id, description, language, name)
+values(1, 1, 'test description', 'EN', 'test name'), (1, 2, '간단설명', 'KO', '테스트 이름')

--- a/src/test/java/com/happypill/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/CategoryServiceTest.java
@@ -1,0 +1,61 @@
+package com.happypill.application.service;
+
+import com.happypill.application.dto.response.CategoryResponse;
+import com.happypill.application.entity.Category;
+import com.happypill.application.entity.CategoryInfo;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryServiceTest {
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Mock
+    private CategoryInfoRepository categoryInfoRepository;
+
+    @Test
+    @DisplayName("카테고리 있을 때 불러오기 테스트")
+    public void shouldReturnCategories() {
+        Language language = Language.KO;
+        Category category = Category.of(1L, "first thum url", "first banner url");
+        List<CategoryInfo> categoryResponses = Arrays.asList(
+                CategoryInfo.of(1L, Language.KO, "first name", "first desc", category),
+                CategoryInfo.of(2L, Language.KO, "second name", "second desc", category)
+        );
+
+        BDDMockito.given(categoryInfoRepository.findByLanguage(language)).willReturn(categoryResponses);
+
+        List<CategoryResponse> result = categoryService.getAllCategories(language);
+
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("카테고리 없을 때 불러오기 테스트")
+    public void shouldReturnEmptyDto() {
+        Language language = Language.KO;
+        List<CategoryInfo> categoryResponses = new ArrayList<>();
+
+        BDDMockito.given(categoryInfoRepository.findByLanguage(language)).willReturn(categoryResponses);
+
+        List<CategoryResponse> result = categoryService.getAllCategories(language);
+
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(0);
+    }
+}

--- a/src/test/java/com/happypill/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/CategoryServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +19,6 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@Testcontainers
 @Transactional
 public class CategoryServiceTest {
     @Autowired

--- a/src/test/java/com/happypill/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/CategoryServiceTest.java
@@ -4,42 +4,48 @@ import com.happypill.application.dto.response.CategoryResponse;
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
 import com.happypill.application.entity.enums.Language;
+import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
-import org.junit.jupiter.api.Test;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@Testcontainers
+@Transactional
 public class CategoryServiceTest {
-    @InjectMocks
+    @Autowired
     private CategoryService categoryService;
 
-    @Mock
+    @Autowired
     private CategoryInfoRepository categoryInfoRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
 
     @Test
     @DisplayName("카테고리 있을 때 불러오기 테스트")
     public void shouldReturnCategories() {
-        Language language = Language.KO;
+        Locale locale = Locale.of("KO");
         Category category = Category.of(1L, "first thum url", "first banner url");
         List<CategoryInfo> categoryResponses = Arrays.asList(
                 CategoryInfo.of(1L, Language.KO, "first name", "first desc", category),
                 CategoryInfo.of(2L, Language.KO, "second name", "second desc", category)
         );
 
-        BDDMockito.given(categoryInfoRepository.findByLanguage(language)).willReturn(categoryResponses);
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryResponses);
 
-        List<CategoryResponse> result = categoryService.getAllCategories(language);
+        List<CategoryResponse> result = categoryService.getAllCategories(locale);
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(2);
@@ -48,12 +54,9 @@ public class CategoryServiceTest {
     @Test
     @DisplayName("카테고리 없을 때 불러오기 테스트")
     public void shouldReturnEmptyDto() {
-        Language language = Language.KO;
-        List<CategoryInfo> categoryResponses = new ArrayList<>();
+        Locale locale = Locale.of("KO");
 
-        BDDMockito.given(categoryInfoRepository.findByLanguage(language)).willReturn(categoryResponses);
-
-        List<CategoryResponse> result = categoryService.getAllCategories(language);
+        List<CategoryResponse> result = categoryService.getAllCategories(locale);
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(0);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,12 @@ spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:postgresql:17:///testdb
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate.hibernate.format_sql: true
 
 
   autoconfigure:


### PR DESCRIPTION
# 티켓
HP-54

# 설명
전체 카테고리 조회용 endpoint 

## 타입
- [ ] 버그
- [X] 작업
- [ ] 기능 향상

# 테스트 방법
API 호출

# 체크리스트
- [X] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [X] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [X] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 카테고리 정보를 다국어로 조회할 수 있는 REST API 엔드포인트가 추가되었습니다.
    - 카테고리 정보를 반환하는 응답 형식이 새롭게 도입되었습니다.
    - 언어별 카테고리 정보를 조회하는 기능이 서비스에 포함되었습니다.

- **데이터베이스**
    - 카테고리 및 카테고리 정보에 대한 초기 데이터가 추가되었습니다.

- **버그 수정**
    - 언어 헤더 파싱 시 잘못된 값이 입력되면 기본값(한국어)으로 처리됩니다.

- **테스트**
    - 카테고리 서비스의 동작을 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->