### PR TITLE
Hp 66/user features

### DIFF
--- a/src/main/java/com/happypill/api/config/auth/oauth2/userprovision/GoogleProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/config/auth/oauth2/userprovision/GoogleProvisionStrategy.java
@@ -29,6 +29,13 @@ public class GoogleProvisionStrategy extends OAuth2UserProvisionStrategy {
     protected HappypillUser createUser(OAuth2User oAuth2User) {
         String sub = oAuth2User.getAttribute("sub");
         String email = oAuth2User.getAttribute("email");
-        return HappypillUser.ofSocial(SnowflakeUtil.nextId(), null, Provider.GOOGLE, sub, email, Role.USER);
+        return HappypillUser.ofSocial(
+                SnowflakeUtil.nextId(),
+                null,
+                Provider.GOOGLE,
+                sub,
+                email,
+                email,
+                Role.USER);
     }
 }

--- a/src/main/java/com/happypill/api/config/auth/oauth2/userprovision/KakaoProvisionStrategy.java
+++ b/src/main/java/com/happypill/api/config/auth/oauth2/userprovision/KakaoProvisionStrategy.java
@@ -29,6 +29,14 @@ public class KakaoProvisionStrategy extends OAuth2UserProvisionStrategy {
     protected HappypillUser createUser(OAuth2User oAuth2User) {
         String sub = oAuth2User.getAttribute("sub");
         String email = oAuth2User.getAttribute("email");
-        return HappypillUser.ofSocial(SnowflakeUtil.nextId(), null, Provider.KAKAO, sub, email, Role.USER);
+        return HappypillUser.ofSocial(
+                SnowflakeUtil.nextId(),
+                null,
+                Provider.KAKAO,
+                sub,
+                email,
+                email,
+                Role.USER
+        );
     }
 }

--- a/src/main/java/com/happypill/api/controller/UserController.java
+++ b/src/main/java/com/happypill/api/controller/UserController.java
@@ -1,0 +1,48 @@
+package com.happypill.api.controller;
+
+import com.happypill.api.config.auth.usercontext.HappypillUser;
+import com.happypill.application.auth.UserContext;
+import com.happypill.application.service.user.UserService;
+import com.happypill.application.service.user.request.UserUpdateRequest;
+import com.happypill.application.service.user.response.UserInfoResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/api/user/me")
+    @PreAuthorize("hasAuthority('USER')")
+    public UserInfoResponse getCurrentUser(@HappypillUser UserContext userContext) {
+        return userService.getCurrentUserInfo(userContext);
+    }
+
+    @PatchMapping("/api/user/me")
+    @PreAuthorize("hasAnyAuthority('USER')")
+    public UserInfoResponse updateCurrentUser(@HappypillUser UserContext userContext, @RequestBody @Valid UserUpdateRequest userUpdateRequest) {
+        return userService.updateCurrentUser(userContext, userUpdateRequest);
+    }
+
+    @DeleteMapping("/api/user/me")
+    @PreAuthorize("hasRole('USER')")
+    public void deleteCurrentUser() {
+        throw new AssertionError("not implemented yet");
+    }
+
+    @PostMapping("/api/user/me/email/verification-request")
+    @PreAuthorize("hasRole('USER')")
+    public void sendEmailVerificationCode() {
+        throw new AssertionError("not implemented yet");
+    }
+
+    @PostMapping("/api/user/me/email/verification-confirm")
+    @PreAuthorize("hasRole('USER')")
+    public void verifyEmailCode() {
+        throw new AssertionError("not implemented yet");
+    }
+}

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -34,12 +34,18 @@ public class HappypillUser extends BaseEntity {
 
     private String loginEmail;
 
+    private String notifyEmail;
+
     private boolean isDeleted;
 
     @Enumerated(STRING)
     private Role role;
 
-    public static HappypillUser ofSocial(@Nullable Long id, String nickName, Provider provider, String socialSub, String loginEmail, Role role) {
-        return new HappypillUser(id, nickName, provider, socialSub, loginEmail, false, role);
+    public static HappypillUser ofSocial(@Nullable Long id, String nickName, Provider provider, String socialSub, String loginEmail, String notifyEmail, Role role) {
+        return new HappypillUser(id, nickName, provider, socialSub, loginEmail, notifyEmail, false, role);
+    }
+
+    public void changeUser(String nickName) {
+        this.nickName = nickName;
     }
 }

--- a/src/main/java/com/happypill/application/service/user/UserService.java
+++ b/src/main/java/com/happypill/application/service/user/UserService.java
@@ -2,6 +2,7 @@ package com.happypill.application.service.user;
 
 import com.happypill.application.auth.UserContext;
 import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import com.happypill.application.service.user.request.UserUpdateRequest;
 import com.happypill.application.service.user.response.UserInfoResponse;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.happypill.application.exception.custom.ExceptionCode.USER_NOT_FOUND;
 
 @Service
 @Slf4j
@@ -19,14 +22,14 @@ public class UserService {
 
     public UserInfoResponse getCurrentUserInfo(UserContext userContext) {
         HappypillUser user = userRepository.findById(userContext.getId())
-                .orElseThrow(() -> new RuntimeException("추후 도메인 에러로 변경"));
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
         return UserInfoResponse.from(user);
     }
 
     @Transactional
     public UserInfoResponse updateCurrentUser(UserContext userContext, UserUpdateRequest userUpdateRequest) {
         HappypillUser user = userRepository.findById(userContext.getId())
-                .orElseThrow(() -> new RuntimeException("추후 도메인 에러로 변경"));
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
         user.changeUser(userUpdateRequest.nickName());
         return UserInfoResponse.from(user);
     }

--- a/src/main/java/com/happypill/application/service/user/UserService.java
+++ b/src/main/java/com/happypill/application/service/user/UserService.java
@@ -1,0 +1,33 @@
+package com.happypill.application.service.user;
+
+import com.happypill.application.auth.UserContext;
+import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import com.happypill.application.service.user.request.UserUpdateRequest;
+import com.happypill.application.service.user.response.UserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    private final HappypillUserRepository userRepository;
+
+    public UserInfoResponse getCurrentUserInfo(UserContext userContext) {
+        HappypillUser user = userRepository.findById(userContext.getId())
+                .orElseThrow(() -> new RuntimeException("추후 도메인 에러로 변경"));
+        return UserInfoResponse.from(user);
+    }
+
+    @Transactional
+    public UserInfoResponse updateCurrentUser(UserContext userContext, UserUpdateRequest userUpdateRequest) {
+        HappypillUser user = userRepository.findById(userContext.getId())
+                .orElseThrow(() -> new RuntimeException("추후 도메인 에러로 변경"));
+        user.changeUser(userUpdateRequest.nickName());
+        return UserInfoResponse.from(user);
+    }
+}

--- a/src/main/java/com/happypill/application/service/user/request/UserUpdateRequest.java
+++ b/src/main/java/com/happypill/application/service/user/request/UserUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.happypill.application.service.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserUpdateRequest(
+        @NotBlank(message = "닉네임은 비어 있을 수 없습니다")
+        String nickName
+) {
+}

--- a/src/main/java/com/happypill/application/service/user/response/UserInfoResponse.java
+++ b/src/main/java/com/happypill/application/service/user/response/UserInfoResponse.java
@@ -1,0 +1,31 @@
+package com.happypill.application.service.user.response;
+
+import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.entity.enums.Provider;
+import com.happypill.application.entity.enums.Role;
+
+import java.time.ZonedDateTime;
+
+public record UserInfoResponse(
+        Long userId,
+        Provider provider,
+        String nickname,
+        String loginEmail,
+        String notifyEmail,
+        Role role,
+        ZonedDateTime createdAt,
+        ZonedDateTime updatedAt
+) {
+    public static UserInfoResponse from(HappypillUser happypillUser) {
+        return new UserInfoResponse(
+                happypillUser.getUserId(),
+                happypillUser.getProvider(),
+                happypillUser.getNickName(),
+                happypillUser.getLoginEmail(),
+                happypillUser.getNotifyEmail(),
+                happypillUser.getRole(),
+                happypillUser.getCreatedAt(),
+                happypillUser.getUpdatedAt()
+        );
+    }
+}


### PR DESCRIPTION
# 티켓
Hp 66

# 설명
- 누락되었던 notifyEmail 추가
- 로그인한 유저가 자기자신의 정보를 조회/업데이트(현재 닉네임만) 할 수 있는 기능 구현
- 기획된 엔드포인트에서 me 추가
  - GET /api/user => 유저리스트조회로 혼동가능
  - POST /api/user => 유저 생성으로 혼동가능
  - 유저 정보조회시, 생성일 등의 정보 추가

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
테스트 할만한 로직이 없어 생략

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다