### PR TITLE
HP-53: 메인페이지 모든 상품 조회 endpoint

### DIFF
--- a/src/main/java/com/happypill/api/controller/CategoryController.java
+++ b/src/main/java/com/happypill/api/controller/CategoryController.java
@@ -1,7 +1,7 @@
 package com.happypill.api.controller;
 
-import com.happypill.application.dto.response.CategoryResponse;
-import com.happypill.application.service.CategoryService;
+import com.happypill.application.service.category.dto.response.CategoryResponse;
+import com.happypill.application.service.category.CategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/src/main/java/com/happypill/api/controller/ProductController.java
+++ b/src/main/java/com/happypill/api/controller/ProductController.java
@@ -1,0 +1,24 @@
+package com.happypill.api.controller;
+
+import com.happypill.application.service.product.ProductService;
+import com.happypill.application.service.product.dto.response.ProductResponse;
+import com.happypill.application.service.product.dto.response.CustomPageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Locale;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/products")
+public class ProductController {
+    private static final String LANGUAGE_HEADER = "Language";
+    private final ProductService productService;
+
+    @GetMapping
+    public CustomPageResponse<ProductResponse> getProducts(@RequestParam Long categoryId, @RequestParam(required = false) Long lastProductId,
+                                                           @RequestHeader(LANGUAGE_HEADER) String headerLanguage, @RequestParam int size) {
+        Locale locale = Locale.of(headerLanguage);
+        return productService.getAllProducts(categoryId, lastProductId, locale, size);
+    }
+}

--- a/src/main/java/com/happypill/application/entity/Product.java
+++ b/src/main/java/com/happypill/application/entity/Product.java
@@ -1,15 +1,18 @@
 package com.happypill.application.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
 @Table(name = "products")
 public class Product extends BaseEntity{
 
@@ -27,4 +30,8 @@ public class Product extends BaseEntity{
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    public static Product of(Long productId, Integer stock, String thumbnailUrl, Category category) {
+        return new Product(productId, stock, true, thumbnailUrl, false, category);
+    }
 }

--- a/src/main/java/com/happypill/application/entity/ProductInfo.java
+++ b/src/main/java/com/happypill/application/entity/ProductInfo.java
@@ -3,16 +3,19 @@ package com.happypill.application.entity;
 
 import com.happypill.application.entity.enums.Language;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
 @Table(name = "product_info")
 public class ProductInfo extends BaseEntity{
 
@@ -41,4 +44,12 @@ public class ProductInfo extends BaseEntity{
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
+
+    public static ProductInfo of(Long productInfoId, Language language, String name, String quantityDetails,
+                                          String warningMessage, String usage, String contentImage, String description,
+                                          String company, String briefDescription, Product product) {
+        return new ProductInfo(productInfoId, language, name, quantityDetails, warningMessage, usage, contentImage,
+                description, company, briefDescription, product);
+
+    }
 }

--- a/src/main/java/com/happypill/application/entity/ProductPrice.java
+++ b/src/main/java/com/happypill/application/entity/ProductPrice.java
@@ -1,15 +1,18 @@
 package com.happypill.application.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
 @Table(name = "product_prices")
 public class ProductPrice extends BaseEntity{
 
@@ -23,4 +26,8 @@ public class ProductPrice extends BaseEntity{
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
+
+    public static ProductPrice of(Long productPriceId, Integer price, boolean isUsed, Product product) {
+        return new ProductPrice(productPriceId, price, isUsed, product);
+    }
 }

--- a/src/main/java/com/happypill/application/repository/product/ProductRepository.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepository.java
@@ -1,7 +1,46 @@
 package com.happypill.application.repository.product;
 
 import com.happypill.application.entity.Product;
+import com.happypill.application.entity.ProductInfo;
+import com.happypill.application.entity.enums.Language;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    @Query("""
+            SELECT pi
+            FROM ProductInfo pi
+            JOIN pi.product p
+            JOIN p.category c
+            WHERE c.id = :categoryId
+              AND pi.language = :language
+              AND p.createdAt > :createdAt
+            """)
+    List<ProductInfo> getAllProductInfoByCategory(@Param("categoryId")Long categoryId, @Param("createdAt")ZonedDateTime createdAt,
+                                               @Param("language") Language language);
+
+    @Query("""
+            SELECT pi
+            FROM ProductInfo pi
+            JOIN pi.product p
+            JOIN p.category c
+            WHERE c.id = :categoryId
+              AND pi.language = :language
+            """)
+    List<ProductInfo> getAllProductInfoByCategory(@Param("categoryId")Long categoryId,
+                                               @Param("language") Language language);
+
+    @Query(""" 
+            SELECT pi
+            FROM ProductInfo pi
+            JOIN pi.product p
+            WHERE pi.language = :language
+                AND p.productId = :productId
+            """)
+    Optional<ProductInfo> getProductInfoByProductId(@Param("productId")Long productId, @Param("language") Language language);
 }

--- a/src/main/java/com/happypill/application/repository/productprice/ProductPriceRepository.java
+++ b/src/main/java/com/happypill/application/repository/productprice/ProductPriceRepository.java
@@ -2,6 +2,18 @@ package com.happypill.application.repository.productprice;
 
 import com.happypill.application.entity.ProductPrice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ProductPriceRepository extends JpaRepository<ProductPrice, Long> {
+    @Query("""
+            SELECT pp
+            FROM ProductPrice pp
+            JOIN pp.product p
+            WHERE p.id = :productId
+              AND pp.isUsed = true
+            """)
+    Optional<ProductPrice> getCurrentPriceByProductInfoId(@Param("productId")Long productId);
 }

--- a/src/main/java/com/happypill/application/service/category/CategoryService.java
+++ b/src/main/java/com/happypill/application/service/category/CategoryService.java
@@ -1,6 +1,6 @@
-package com.happypill.application.service;
+package com.happypill.application.service.category;
 
-import com.happypill.application.dto.response.CategoryResponse;
+import com.happypill.application.service.category.dto.response.CategoryResponse;
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
 import com.happypill.application.entity.enums.Language;

--- a/src/main/java/com/happypill/application/service/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/happypill/application/service/category/dto/response/CategoryResponse.java
@@ -1,4 +1,4 @@
-package com.happypill.application.dto.response;
+package com.happypill.application.service.category.dto.response;
 
 public record CategoryResponse (
      Long categoryId,

--- a/src/main/java/com/happypill/application/service/product/ProductService.java
+++ b/src/main/java/com/happypill/application/service/product/ProductService.java
@@ -1,0 +1,68 @@
+package com.happypill.application.service.product;
+
+import com.happypill.application.entity.ProductInfo;
+import com.happypill.application.entity.ProductPrice;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.exception.custom.ExceptionCode;
+import com.happypill.application.exception.global.BusinessException;
+import com.happypill.application.repository.product.ProductRepository;
+import com.happypill.application.repository.productprice.ProductPriceRepository;
+import com.happypill.application.service.product.dto.response.ProductResponse;
+import com.happypill.application.service.product.dto.response.CustomPageResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final ProductPriceRepository productPriceRepository;
+
+    public CustomPageResponse<ProductResponse> getAllProducts(Long categoryId, Long lastProductId, Locale locale, int size) {
+        Language language = Language.parseLanguage(locale.getLanguage());
+        List<ProductInfo> productInfos;
+        if (lastProductId != null) {
+            // TO DO Change to ExceptionCode.Product_Info_not_found
+            ZonedDateTime createdAt = productRepository.getProductInfoByProductId(lastProductId, language).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND)).getProduct().getCreatedAt();
+            productInfos = productRepository.getAllProductInfoByCategory(categoryId, createdAt, language);
+        } else {
+            productInfos = productRepository.getAllProductInfoByCategory(categoryId, language);
+        }
+        boolean hasNext = productInfos.size() > size;
+        List<ProductInfo> productInfoList = hasNext ? productInfos.subList(0, size) : productInfos;
+
+        if (productInfos.isEmpty()) {
+            return new CustomPageResponse<>(
+                    productInfoList.stream()
+                            .map(pi -> ProductResponse.from(pi, getCurrentPrice(pi)))
+                            .toList(),
+                    false,
+                    null
+            );
+        }
+
+        CustomPageResponse<ProductResponse> response = new CustomPageResponse<>(
+                productInfoList.stream()
+                        .map(pi -> ProductResponse.from(pi, getCurrentPrice(pi)))
+                        .toList(),
+                hasNext,
+                productInfoList.getLast().getProduct().getProductId()
+        );
+
+        return response;
+    }
+
+    private int getCurrentPrice(ProductInfo productInfo) {
+        // TO DO Change to ExceptionCode.Product_price_not_found
+        ProductPrice price = productPriceRepository.getCurrentPriceByProductInfoId(productInfo.getProduct().getProductId()).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+
+        return price.getPrice();
+    }
+}

--- a/src/main/java/com/happypill/application/service/product/dto/response/CustomPageResponse.java
+++ b/src/main/java/com/happypill/application/service/product/dto/response/CustomPageResponse.java
@@ -1,0 +1,5 @@
+package com.happypill.application.service.product.dto.response;
+
+import java.util.List;
+
+public record CustomPageResponse<T> (List<T> products, boolean hasNext, Long lastProductId){}

--- a/src/main/java/com/happypill/application/service/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/happypill/application/service/product/dto/response/ProductResponse.java
@@ -1,0 +1,17 @@
+package com.happypill.application.service.product.dto.response;
+
+import com.happypill.application.entity.Category;
+import com.happypill.application.entity.Product;
+import com.happypill.application.entity.ProductInfo;
+
+public record ProductResponse(Long productId, Long categoryId, String name, String company, int price,
+                              String briefDescription, String thumbnailUrl)
+{
+    public static ProductResponse from(ProductInfo productInfo, Integer price) {
+        Product product = productInfo.getProduct();
+        Category category = product.getCategory();
+
+        return new ProductResponse(product.getProductId(), category.getCategoryId(), productInfo.getName(),
+                productInfo.getCompany(), price, productInfo.getBriefDescription(), product.getThumbnailUrl());
+    }
+}

--- a/src/main/java/com/happypill/application/util/DataInitialiser.java
+++ b/src/main/java/com/happypill/application/util/DataInitialiser.java
@@ -1,0 +1,59 @@
+package com.happypill.application.util;
+
+import com.happypill.application.entity.*;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.repository.category.CategoryRepository;
+import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
+import com.happypill.application.repository.product.ProductRepository;
+import com.happypill.application.repository.productinfo.ProductInfoRepository;
+import com.happypill.application.repository.productprice.ProductPriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitialiser implements ApplicationRunner {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryInfoRepository categoryInfoRepository;
+    private final ProductRepository productRepository;
+    private final ProductInfoRepository productInfoRepository;
+    private final ProductPriceRepository productPriceRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        Category categoryOne = Category.of(SnowflakeUtil.nextId(), "www.category_firstThumbnail.com", "www.category_firstBanner.com");
+        Category categoryTwo = Category.of(SnowflakeUtil.nextId(), "www.category_secondThumbnail.com", "www.category_secondBanner.com");
+        List<Category> categoryList = Arrays.asList(categoryOne, categoryTwo);
+
+        CategoryInfo categoryInfoOne = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", "비타민은 몸에 좋아요",  categoryOne);
+        CategoryInfo categoryInfoTwo = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", "vitamin is necessary for health",  categoryOne);
+        CategoryInfo categoryInfoThree = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분", "몸이 튼튼해져요",  categoryTwo);
+        List<CategoryInfo> categoryInfoList = Arrays.asList(categoryInfoOne, categoryInfoTwo, categoryInfoThree);
+
+        Product productOne = Product.of(SnowflakeUtil.nextId(), 300, "www.product_firstThumbnail.com", categoryOne);
+        Product productTwo = Product.of(SnowflakeUtil.nextId(), 12, "www.product_secondThumbnail.com", categoryOne);
+        List<Product> productList = Arrays.asList(productOne, productTwo);
+
+        ProductInfo productInfoOne = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 C", "30 캡슐", "밥과 함께 드시오", "물과 함께 섭취하시오. 하루에 3개.", "Content image", "매우 강력한 마법의 알약", "삼성제약", "오줌이 노래져요", productOne);
+        ProductInfo productInfoTwo = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin C", "30 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productOne);
+        ProductInfo productInfoThree = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 K", "10 캡슐", "밥과 함께 3알 드세요", "과대 섭취 금지", "Content image", "매우 화려한 알약", "삼성제약", "이건 어디 좋은지 몰라요 저희도", productTwo);
+        List<ProductInfo> productInfoList = Arrays.asList(productInfoOne, productInfoTwo, productInfoThree);
+
+        ProductPrice priceOne = ProductPrice.of(SnowflakeUtil.nextId(), 15000, false, productOne);
+        ProductPrice priceTwo = ProductPrice.of(SnowflakeUtil.nextId(), 25000, true, productOne);
+        ProductPrice priceThree = ProductPrice.of(SnowflakeUtil.nextId(), 8000, true, productTwo);
+        List<ProductPrice> productPriceList = Arrays.asList(priceOne, priceTwo, priceThree);
+
+        categoryRepository.saveAll(categoryList);
+        categoryInfoRepository.saveAll(categoryInfoList);
+        productRepository.saveAll(productList);
+        productInfoRepository.saveAll(productInfoList);
+        productPriceRepository.saveAll(productPriceList);
+    }
+}

--- a/src/main/java/com/happypill/application/util/DataInitialiser.java
+++ b/src/main/java/com/happypill/application/util/DataInitialiser.java
@@ -10,12 +10,14 @@ import com.happypill.application.repository.productprice.ProductPriceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
 
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class DataInitialiser implements ApplicationRunner {
 

--- a/src/test/java/com/happypill/application/service/category/CategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/category/CategoryServiceTest.java
@@ -1,6 +1,6 @@
-package com.happypill.application.service;
+package com.happypill.application.service.category;
 
-import com.happypill.application.dto.response.CategoryResponse;
+import com.happypill.application.service.category.dto.response.CategoryResponse;
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
 import com.happypill.application.entity.enums.Language;

--- a/src/test/java/com/happypill/application/service/category/CategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/category/CategoryServiceTest.java
@@ -1,14 +1,13 @@
 package com.happypill.application.service.category;
 
-import com.happypill.application.service.category.dto.response.CategoryResponse;
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
 import com.happypill.application.entity.enums.Language;
 import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
+import com.happypill.application.service.category.dto.response.CategoryResponse;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -20,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Before All 때문
 public class CategoryServiceTest {
     @Autowired
     private CategoryService categoryService;
@@ -29,6 +29,12 @@ public class CategoryServiceTest {
 
     @Autowired
     private CategoryRepository categoryRepository;
+
+    @AfterEach
+    void clearDB() {
+        categoryInfoRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("카테고리 있을 때 불러오기 테스트")

--- a/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
+++ b/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
@@ -1,0 +1,142 @@
+package com.happypill.application.service.product;
+
+import com.happypill.application.entity.*;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.exception.global.BusinessException;
+import com.happypill.application.repository.category.CategoryRepository;
+import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
+import com.happypill.application.repository.product.ProductRepository;
+import com.happypill.application.repository.productinfo.ProductInfoRepository;
+import com.happypill.application.repository.productprice.ProductPriceRepository;
+import com.happypill.application.service.product.dto.response.CustomPageResponse;
+import com.happypill.application.service.product.dto.response.ProductResponse;
+import com.happypill.application.util.SnowflakeUtil;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Before All 때문
+public class ProductServiceTest {
+    @Autowired
+    private ProductPriceRepository productPriceRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private CategoryInfoRepository categoryInfoRepository;
+
+    @Autowired
+    private ProductInfoRepository productInfoRepository;
+
+    @Autowired
+    private ProductService productService;
+
+    private Long randomCategoryId;
+    private Long randomProductId;
+
+    @BeforeAll
+    void setUpDb() {
+        Category categoryOne = Category.of(SnowflakeUtil.nextId(), "www.category_firstThumbnail.com", "www.category_firstBanner.com");
+        Category categoryTwo = Category.of(SnowflakeUtil.nextId(), "www.category_secondThumbnail.com", "www.category_secondBanner.com");
+        randomCategoryId = categoryOne.getCategoryId();
+        List<Category> categoryList = Arrays.asList(categoryOne, categoryTwo);
+
+        CategoryInfo categoryInfoOne = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", "비타민은 몸에 좋아요",  categoryOne);
+        CategoryInfo categoryInfoTwo = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", "vitamin is necessary for health",  categoryOne);
+        CategoryInfo categoryInfoThree = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분", "몸이 튼튼해져요",  categoryTwo);
+        List<CategoryInfo> categoryInfoList = Arrays.asList(categoryInfoOne, categoryInfoTwo, categoryInfoThree);
+
+        Product productOne = Product.of(SnowflakeUtil.nextId(), 300, "www.product_firstThumbnail.com", categoryOne);
+        Product productTwo = Product.of(SnowflakeUtil.nextId(), 12, "www.product_secondThumbnail.com", categoryOne);
+        randomProductId = productOne.getProductId();
+        List<Product> productList = Arrays.asList(productOne, productTwo);
+
+        ProductInfo productInfoOne = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 C", "30 캡슐", "밥과 함께 드시오", "물과 함께 섭취하시오. 하루에 3개.", "Content image", "매우 강력한 마법의 알약", "삼성제약", "오줌이 노래져요", productOne);
+        ProductInfo productInfoTwo = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin C", "30 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productOne);
+        ProductInfo productInfoThree = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 K", "10 캡슐", "밥과 함께 3알 드세요", "과대 섭취 금지", "Content image", "매우 화려한 알약", "삼성제약", "이건 어디 좋은지 몰라요 저희도", productTwo);
+        List<ProductInfo> productInfoList = Arrays.asList(productInfoOne, productInfoTwo, productInfoThree);
+
+        ProductPrice priceOne = ProductPrice.of(SnowflakeUtil.nextId(), 15000, false, productOne);
+        ProductPrice priceTwo = ProductPrice.of(SnowflakeUtil.nextId(), 25000, true, productOne);
+        ProductPrice priceThree = ProductPrice.of(SnowflakeUtil.nextId(), 8000, true, productTwo);
+        List<ProductPrice> productPriceList = Arrays.asList(priceOne, priceTwo, priceThree);
+
+        categoryRepository.saveAll(categoryList);
+        categoryInfoRepository.saveAll(categoryInfoList);
+        productRepository.saveAll(productList);
+        productInfoRepository.saveAll(productInfoList);
+        productPriceRepository.saveAll(productPriceList);
+    }
+
+    @Test
+    @DisplayName("잘못된 카테고리 아이디 입력")
+    public void getAllProductsWithWrongCategoryId() {
+        Locale locale = Locale.of("KO");
+        Long categoryId = 1L;
+        int size = 4;
+
+        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, null, locale, size);
+
+        assertThat(result).isNotNull();
+        assertThat(result.products()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 카테고리와 마지막 상품 아이디 입력")
+    public void getAllProductsWithWrongCategoryIdAndLastProductId() {
+        Locale locale = Locale.of("KO");
+        Long categoryId = 1L;
+        Long lastProductId = 1L;
+        int size = 4;
+
+        assertThatThrownBy(() -> productService.getAllProducts(categoryId, lastProductId, locale, size))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("해당 사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("첫 알맞은 카테고리 아이디 입력")
+    public void getAllProductsWithoutLastProductId() {
+        Locale locale = Locale.of("KO");
+        Long categoryId = randomCategoryId;
+        Long lastProductId = null;
+        int size = 4;
+
+        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, lastProductId, locale, size);
+
+        assertThat(result).isNotNull();
+        assertThat(result.products()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("알맞은 카테고리 아이디 입력")
+    public void getAllProducts() {
+        Locale locale = Locale.of("KO");
+        Long categoryId = randomCategoryId;
+        Long lastProductId = randomProductId;
+        int size = 4;
+
+        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, lastProductId, locale, size);
+
+        assertThat(result).isNotNull();
+        assertThat(result.products()).hasSize(1);
+    }
+
+}

--- a/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
+++ b/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
@@ -12,10 +12,7 @@ import com.happypill.application.service.product.dto.response.CustomPageResponse
 import com.happypill.application.service.product.dto.response.ProductResponse;
 import com.happypill.application.util.SnowflakeUtil;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -51,8 +48,74 @@ public class ProductServiceTest {
     private Long randomCategoryId;
     private Long randomProductId;
 
-    @BeforeAll
-    void setUpDb() {
+    @AfterEach
+    void clearDB() {
+        productPriceRepository.deleteAll();
+        productInfoRepository.deleteAll();
+        productRepository.deleteAll();
+        categoryInfoRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("잘못된 카테고리 아이디 입력")
+    public void getAllProductsWithWrongCategoryId() {
+        setUpDb();
+        Locale locale = Locale.of("KO");
+        Long categoryId = 1L;
+        int size = 4;
+
+        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, null, locale, size);
+
+        assertThat(result).isNotNull();
+        assertThat(result.products()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 카테고리와 마지막 상품 아이디 입력")
+    public void getAllProductsWithWrongCategoryIdAndLastProductId() {
+        setUpDb();
+        Locale locale = Locale.of("KO");
+        Long categoryId = 1L;
+        Long lastProductId = 1L;
+        int size = 4;
+
+        assertThatThrownBy(() -> productService.getAllProducts(categoryId, lastProductId, locale, size))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("해당 사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("첫 알맞은 카테고리 아이디 입력")
+    public void getAllProductsWithoutLastProductId() {
+        setUpDb();
+        Locale locale = Locale.of("KO");
+        Long categoryId = randomCategoryId;
+        Long lastProductId = null;
+        int size = 4;
+
+        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, lastProductId, locale, size);
+
+        assertThat(result).isNotNull();
+        assertThat(result.products()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("알맞은 카테고리 아이디 입력")
+    public void getAllProducts() {
+        setUpDb();
+        Locale locale = Locale.of("KO");
+        Long categoryId = randomCategoryId;
+        Long lastProductId = randomProductId;
+        int size = 4;
+
+        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, lastProductId, locale, size);
+
+        assertThat(result).isNotNull();
+        assertThat(result.products()).hasSize(1);
+    }
+
+      void setUpDb() {
         Category categoryOne = Category.of(SnowflakeUtil.nextId(), "www.category_firstThumbnail.com", "www.category_firstBanner.com");
         Category categoryTwo = Category.of(SnowflakeUtil.nextId(), "www.category_secondThumbnail.com", "www.category_secondBanner.com");
         randomCategoryId = categoryOne.getCategoryId();
@@ -83,60 +146,6 @@ public class ProductServiceTest {
         productRepository.saveAll(productList);
         productInfoRepository.saveAll(productInfoList);
         productPriceRepository.saveAll(productPriceList);
-    }
-
-    @Test
-    @DisplayName("잘못된 카테고리 아이디 입력")
-    public void getAllProductsWithWrongCategoryId() {
-        Locale locale = Locale.of("KO");
-        Long categoryId = 1L;
-        int size = 4;
-
-        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, null, locale, size);
-
-        assertThat(result).isNotNull();
-        assertThat(result.products()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("잘못된 카테고리와 마지막 상품 아이디 입력")
-    public void getAllProductsWithWrongCategoryIdAndLastProductId() {
-        Locale locale = Locale.of("KO");
-        Long categoryId = 1L;
-        Long lastProductId = 1L;
-        int size = 4;
-
-        assertThatThrownBy(() -> productService.getAllProducts(categoryId, lastProductId, locale, size))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("해당 사용자를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("첫 알맞은 카테고리 아이디 입력")
-    public void getAllProductsWithoutLastProductId() {
-        Locale locale = Locale.of("KO");
-        Long categoryId = randomCategoryId;
-        Long lastProductId = null;
-        int size = 4;
-
-        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, lastProductId, locale, size);
-
-        assertThat(result).isNotNull();
-        assertThat(result.products()).hasSize(2);
-    }
-
-    @Test
-    @DisplayName("알맞은 카테고리 아이디 입력")
-    public void getAllProducts() {
-        Locale locale = Locale.of("KO");
-        Long categoryId = randomCategoryId;
-        Long lastProductId = randomProductId;
-        int size = 4;
-
-        CustomPageResponse<ProductResponse> result = productService.getAllProducts(categoryId, lastProductId, locale, size);
-
-        assertThat(result).isNotNull();
-        assertThat(result.products()).hasSize(1);
     }
 
 }


### PR DESCRIPTION
# 티켓
HP-53

# 설명
메인 페이지 카테고리 상관없이 모든 상품조회
카테고리별 상품 조회 가능

## 타입
- [ ] 버그
- [X] 작업
- [ ] 기능 향상

# 테스트 방법
postman으로 api 테스트

# 체크리스트
- [X] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [X] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [X] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다