### PR TITLE
Hp-73/user email

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,9 +45,13 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
-    testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.testcontainers:junit-jupiter")
+
+
     testImplementation("org.mockito:mockito-inline:5.2.0")
+    testImplementation("net.datafaker:datafaker:2.4.2")
+
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,9 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
-
     implementation ("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
 
     implementation("com.auth0:java-jwt:4.5.0")
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,10 @@ services:
       - "5432:5432"
     command: >
       postgres -c log_statement=all -c logging_collector=off -c log_destination=stderr
+    restart: unless-stopped
+
+  redis:
+    image: redis:8
+    ports:
+      - "6379:6379"
+    restart: unless-stopped

--- a/src/main/java/com/happypill/api/config/auth/jwt/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/happypill/api/config/auth/jwt/security/JwtAuthenticationProvider.java
@@ -34,6 +34,10 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
             Long userId = Long.valueOf(subject);
 
             String[] roles = parsedJwt.getClaim("roles").asArray(String.class);
+            for (int i = 0; i < roles.length; i++) {
+                roles[i] = "ROLE_" + roles[i];
+            }
+
             List<GrantedAuthority> authorityList = AuthorityUtils.createAuthorityList(roles);
 
             return JwtAuthenticationToken.authenticated(SecurityUserContext.from(userId), accessToken, authorityList);

--- a/src/main/java/com/happypill/api/controller/UserController.java
+++ b/src/main/java/com/happypill/api/controller/UserController.java
@@ -3,6 +3,8 @@ package com.happypill.api.controller;
 import com.happypill.api.config.auth.usercontext.HappypillUser;
 import com.happypill.application.auth.UserContext;
 import com.happypill.application.service.user.UserService;
+import com.happypill.application.service.user.request.EmailVerificationRequest;
+import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
 import com.happypill.application.service.user.request.UserUpdateRequest;
 import com.happypill.application.service.user.response.UserInfoResponse;
 import jakarta.validation.Valid;
@@ -19,13 +21,13 @@ public class UserController {
     @GetMapping("/api/user/me")
     @PreAuthorize("hasRole('USER')")
     public UserInfoResponse getCurrentUser(@HappypillUser UserContext userContext) {
-        return userService.getCurrentUserInfo(userContext);
+        return userService.getUserInfo(userContext);
     }
 
     @PatchMapping("/api/user/me")
     @PreAuthorize("hasRole('USER')")
     public UserInfoResponse updateCurrentUser(@HappypillUser UserContext userContext, @RequestBody @Valid UserUpdateRequest userUpdateRequest) {
-        return userService.updateCurrentUser(userContext, userUpdateRequest);
+        return userService.updateUser(userContext, userUpdateRequest);
     }
 
     @DeleteMapping("/api/user/me")
@@ -36,13 +38,14 @@ public class UserController {
 
     @PostMapping("/api/user/me/email/verification-request")
     @PreAuthorize("hasRole('USER')")
-    public void sendEmailVerificationCode() {
-        throw new AssertionError("not implemented yet");
+    public void sendNotifyEmailVerificationCode(@HappypillUser UserContext userContext, @RequestBody @Valid EmailVerificationRequest request) {
+        userService.sendEmailVerificationCode(userContext, request);
     }
 
     @PostMapping("/api/user/me/email/verification-confirm")
     @PreAuthorize("hasRole('USER')")
-    public void verifyEmailCode() {
-        throw new AssertionError("not implemented yet");
+    public void verifyAndUpdateNotifyEmail(@HappypillUser UserContext userContext,
+                                           @RequestBody @Valid UserNotifyEmailUpdateRequest request) {
+        userService.verifyAndUpdateUserNotifyEmail(userContext, request);
     }
 }

--- a/src/main/java/com/happypill/api/controller/UserController.java
+++ b/src/main/java/com/happypill/api/controller/UserController.java
@@ -17,13 +17,13 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/api/user/me")
-    @PreAuthorize("hasAuthority('USER')")
+    @PreAuthorize("hasRole('USER')")
     public UserInfoResponse getCurrentUser(@HappypillUser UserContext userContext) {
         return userService.getCurrentUserInfo(userContext);
     }
 
     @PatchMapping("/api/user/me")
-    @PreAuthorize("hasAnyAuthority('USER')")
+    @PreAuthorize("hasRole('USER')")
     public UserInfoResponse updateCurrentUser(@HappypillUser UserContext userContext, @RequestBody @Valid UserUpdateRequest userUpdateRequest) {
         return userService.updateCurrentUser(userContext, userUpdateRequest);
     }

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -2,7 +2,6 @@ package com.happypill.application.entity;
 
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
-import jakarta.annotation.Nullable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
@@ -41,11 +40,15 @@ public class HappypillUser extends BaseEntity {
     @Enumerated(STRING)
     private Role role;
 
-    public static HappypillUser ofSocial(@Nullable Long id, String nickName, Provider provider, String socialSub, String loginEmail, String notifyEmail, Role role) {
+    public static HappypillUser ofSocial(Long id, String nickName, Provider provider, String socialSub, String loginEmail, String notifyEmail, Role role) {
         return new HappypillUser(id, nickName, provider, socialSub, loginEmail, notifyEmail, false, role);
     }
 
     public void changeUser(String nickName) {
         this.nickName = nickName;
+    }
+
+    public void changeNotifyEmail(String notifyEmail) {
+        this.notifyEmail = notifyEmail;
     }
 }

--- a/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
+++ b/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
@@ -8,7 +8,9 @@ import static org.springframework.http.HttpStatus.*;
 @Getter
 public enum ExceptionCode {
 
-    USER_NOT_FOUND(NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    EMAIL_REQUEST_COUNT_EXCEED(TOO_MANY_REQUESTS, "요청 기능 횟수를 초과했습니다"),
+    EMAIL_VERIFICATION_CODE_NOT_FOUND(BAD_REQUEST, "인증 코드가 만료되었거나 존재하지 않습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/happypill/application/exception/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/happypill/application/exception/global/GlobalExceptionHandler.java
@@ -1,13 +1,17 @@
 package com.happypill.application.exception.global;
 
 import com.happypill.application.exception.custom.ExceptionCode;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     // @Valid 검증 실패 처리
@@ -21,7 +25,7 @@ public class GlobalExceptionHandler {
                 .orElse("잘못된 요청입니다.");
 
         ErrorResponse<Object> response = new ErrorResponse<>(message, null);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        return ResponseEntity.status(BAD_REQUEST).body(response);
     }
 
     @ExceptionHandler(BusinessException.class)
@@ -34,5 +38,11 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(code.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse<?>> handleUnexpectedException(RuntimeException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(new ErrorResponse<>("예상치 못한 오류가 발생했습니다.", null));
     }
 }

--- a/src/main/java/com/happypill/application/service/user/EmailVerificationRedisRepository.java
+++ b/src/main/java/com/happypill/application/service/user/EmailVerificationRedisRepository.java
@@ -1,0 +1,51 @@
+package com.happypill.application.service.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class EmailVerificationRedisRepository {
+
+    // email:verification:request-count:1
+    private static final String EMAIL_VERIFICATION_REQUEST_COUNT = "email:verification:request-count:%s";
+
+    // email:verification:verifyCode:11111:22222
+    private static final String EMAIL_VERIFICATION_CODE_KEY = "email:verification:verifyCode:%s:%s";
+
+    private final StringRedisTemplate redisTemplate;
+
+    private String generateRequestCountKey(String userId) {
+        return String.format(EMAIL_VERIFICATION_REQUEST_COUNT, userId);
+    }
+
+    private String generateVerificationCodeKey(String userId, String notifyEmail) {
+        return String.format(EMAIL_VERIFICATION_CODE_KEY, userId, notifyEmail);
+    }
+
+    public Long increaseRequestCount(Long userId, Duration ttl) { //TODO lua script
+        String key = generateRequestCountKey(String.valueOf(userId));
+        log.info("key = {}", key);
+        if (redisTemplate.opsForValue().setIfAbsent(key, "1", ttl)) {
+            return 1L;
+        }
+        return redisTemplate.opsForValue().increment(key);
+    }
+
+    public void saveVerificationCode(Long userId, String notifyEmail, String verifyCode, Duration ttl) {
+        String key = generateVerificationCodeKey(String.valueOf(userId), notifyEmail);
+        redisTemplate.opsForValue().set(key, verifyCode, ttl);
+    }
+
+    public Optional<String> getVerificationCode(Long userId, String notifyEmail) {
+        String key = generateVerificationCodeKey(String.valueOf(userId), notifyEmail);
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+    }
+
+}

--- a/src/main/java/com/happypill/application/service/user/UserService.java
+++ b/src/main/java/com/happypill/application/service/user/UserService.java
@@ -1,9 +1,13 @@
 package com.happypill.application.service.user;
 
 import com.happypill.application.auth.UserContext;
+import com.happypill.application.email.EmailSender;
 import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import com.happypill.application.service.user.request.EmailVerificationRequest;
+import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
 import com.happypill.application.service.user.request.UserUpdateRequest;
 import com.happypill.application.service.user.response.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+
+import static com.happypill.application.exception.custom.ExceptionCode.EMAIL_VERIFICATION_CODE_NOT_FOUND;
 import static com.happypill.application.exception.custom.ExceptionCode.USER_NOT_FOUND;
 
 @Service
@@ -18,19 +25,57 @@ import static com.happypill.application.exception.custom.ExceptionCode.USER_NOT_
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
+
+    private static final int EMAIL_REQUEST_COUNT_LIMIT = 3;
+
+    private static final Duration EMAIL_REQUEST_COUNT_TTL = Duration.ofDays(1);
+
+    private static final Duration VERIFY_CODE_TTL = Duration.ofMinutes(3);
+
     private final HappypillUserRepository userRepository;
 
-    public UserInfoResponse getCurrentUserInfo(UserContext userContext) {
+    private final EmailVerificationRedisRepository emailVerificationRedisRepository;
+
+    private final EmailSender emailSender;
+
+    private final VerifyCodeGenerator verifyCodeGenerator;
+
+    public UserInfoResponse getUserInfo(UserContext userContext) {
         HappypillUser user = userRepository.findById(userContext.getId())
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
         return UserInfoResponse.from(user);
     }
 
     @Transactional
-    public UserInfoResponse updateCurrentUser(UserContext userContext, UserUpdateRequest userUpdateRequest) {
+    public UserInfoResponse updateUser(UserContext userContext, UserUpdateRequest userUpdateRequest) {
         HappypillUser user = userRepository.findById(userContext.getId())
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
         user.changeUser(userUpdateRequest.nickName());
         return UserInfoResponse.from(user);
     }
+
+    public void sendEmailVerificationCode(UserContext userContext, EmailVerificationRequest request) {
+        Long count = emailVerificationRedisRepository.increaseRequestCount(userContext.getId(), EMAIL_REQUEST_COUNT_TTL);
+        if (count > EMAIL_REQUEST_COUNT_LIMIT) {
+            throw new BusinessException(ExceptionCode.EMAIL_REQUEST_COUNT_EXCEED);
+        }
+        String verifyCode = verifyCodeGenerator.generate();
+        emailVerificationRedisRepository.saveVerificationCode(userContext.getId(), request.notifyEmail(), verifyCode, VERIFY_CODE_TTL);
+        emailSender.send(request.notifyEmail(), verifyCode); // TODO ASYNC
+    }
+
+    @Transactional
+    public void verifyAndUpdateUserNotifyEmail(UserContext userContext, UserNotifyEmailUpdateRequest request) {
+        verifyNotifyEmail(userContext, request);
+        HappypillUser user = userRepository.findById(userContext.getId())
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+        user.changeNotifyEmail(request.notifyEmail());
+    }
+
+    private void verifyNotifyEmail(UserContext userContext, UserNotifyEmailUpdateRequest request) {
+        emailVerificationRedisRepository.getVerificationCode(userContext.getId(), request.notifyEmail())
+                .filter(code -> request.verifyCode().equals(code))
+                .orElseThrow(() -> new BusinessException(EMAIL_VERIFICATION_CODE_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/happypill/application/service/user/UserService.java
+++ b/src/main/java/com/happypill/application/service/user/UserService.java
@@ -6,6 +6,7 @@ import com.happypill.application.entity.HappypillUser;
 import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import com.happypill.application.service.user.email.EmailVerificationRedisRepository;
 import com.happypill.application.service.user.request.EmailVerificationRequest;
 import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
 import com.happypill.application.service.user.request.UserUpdateRequest;

--- a/src/main/java/com/happypill/application/service/user/VerifyCodeGenerator.java
+++ b/src/main/java/com/happypill/application/service/user/VerifyCodeGenerator.java
@@ -1,0 +1,15 @@
+package com.happypill.application.service.user;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+@Component
+public class VerifyCodeGenerator {
+    private final Random random = new SecureRandom();
+
+    public String generate() {
+        return String.valueOf(random.nextInt(900000) + 100000);
+    }
+}

--- a/src/main/java/com/happypill/application/service/user/email/EmailVerificationRedisRepository.java
+++ b/src/main/java/com/happypill/application/service/user/email/EmailVerificationRedisRepository.java
@@ -1,4 +1,4 @@
-package com.happypill.application.service.user;
+package com.happypill.application.service.user.email;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/happypill/application/service/user/request/EmailVerificationRequest.java
+++ b/src/main/java/com/happypill/application/service/user/request/EmailVerificationRequest.java
@@ -1,0 +1,11 @@
+package com.happypill.application.service.user.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record EmailVerificationRequest(
+        @Email
+        @NotNull
+        String notifyEmail
+) {
+}

--- a/src/main/java/com/happypill/application/service/user/request/UserNotifyEmailUpdateRequest.java
+++ b/src/main/java/com/happypill/application/service/user/request/UserNotifyEmailUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.happypill.application.service.user.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserNotifyEmailUpdateRequest(
+        @NotBlank(message = "인증 코드가 제공되지 않았습니다.")
+        String verifyCode,
+        @NotNull(message = "변경할 이메일이 제공되지 않았습니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        String notifyEmail
+) {
+}

--- a/src/main/java/com/happypill/application/util/DataSerializerUtil.java
+++ b/src/main/java/com/happypill/application/util/DataSerializerUtil.java
@@ -1,0 +1,43 @@
+package com.happypill.application.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Slf4j
+@NoArgsConstructor(access = PRIVATE)
+public final class DataSerializerUtil {
+    private static final ObjectMapper objectMapper = init();
+
+    private static ObjectMapper init() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+
+    public static <T> T deserialize(String data, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(data, clazz);
+        } catch (JsonProcessingException e) {
+            String msg = String.format("[DataSerializer.deserialize] data=%s, clazz=%s", data, clazz.getName());
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+    public static <T> T deserialize(Object data, Class<T> clazz) {
+        return objectMapper.convertValue(data, clazz);
+    }
+
+    public static String serialize(Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(String.format("[DataSerializer.serialize] object=%s", object), e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,8 +12,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: ${EMAIL_ID}
-    password: ${EMAIL_PW}
+    username: ${EMAIL_ID:test}
+    password: ${EMAIL_PW:test}
     properties:
       mail:
         smtp:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,7 +72,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
 
 --- # prod
 spring.config.activate.on-profile: prod

--- a/src/test/java/com/happypill/application/service/IntegrationTestSupport.java
+++ b/src/test/java/com/happypill/application/service/IntegrationTestSupport.java
@@ -1,22 +1,27 @@
 package com.happypill.application.service;
 
 import com.happypill.application.email.EmailSender;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 public abstract class IntegrationTestSupport {
 
+    @Container
     protected static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:8")
             .withExposedPorts(6379);
 
-    static {
-        redisContainer.start();
-        System.setProperty("spring.redis.host", redisContainer.getHost());
-        System.setProperty("spring.redis.port", String.valueOf(redisContainer.getMappedPort(6379)));
+    @DynamicPropertySource
+    static void configureRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
     }
 
     @MockitoBean
     protected EmailSender emailSender;
-
 
 }

--- a/src/test/java/com/happypill/application/service/IntegrationTestSupport.java
+++ b/src/test/java/com/happypill/application/service/IntegrationTestSupport.java
@@ -1,0 +1,22 @@
+package com.happypill.application.service;
+
+import com.happypill.application.email.EmailSender;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.GenericContainer;
+
+public abstract class IntegrationTestSupport {
+
+    protected static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:8")
+            .withExposedPorts(6379);
+
+    static {
+        redisContainer.start();
+        System.setProperty("spring.redis.host", redisContainer.getHost());
+        System.setProperty("spring.redis.port", String.valueOf(redisContainer.getMappedPort(6379)));
+    }
+
+    @MockitoBean
+    protected EmailSender emailSender;
+
+
+}

--- a/src/test/java/com/happypill/application/service/user/UserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/user/UserServiceTest.java
@@ -1,0 +1,103 @@
+package com.happypill.application.service.user;
+
+import com.happypill.api.config.auth.usercontext.SecurityUserContext;
+import com.happypill.application.auth.UserContext;
+import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.entity.enums.Provider;
+import com.happypill.application.entity.enums.Role;
+import com.happypill.application.exception.custom.ExceptionCode;
+import com.happypill.application.exception.global.BusinessException;
+import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import com.happypill.application.service.IntegrationTestSupport;
+import com.happypill.application.service.user.request.EmailVerificationRequest;
+import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
+import com.happypill.application.util.SnowflakeUtil;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class UserServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UserService service;
+
+    @Autowired
+    private HappypillUserRepository userRepository;
+
+    @Autowired
+    private EmailVerificationRedisRepository emailVerificationRedisRepository;
+
+    private final Faker faker = new Faker();
+
+    private HappypillUser generateTestUser() {
+        String email = faker.internet().emailAddress();
+        return userRepository.save(HappypillUser.ofSocial(
+                SnowflakeUtil.nextId(),
+                "nickname",
+                Provider.GOOGLE,
+                String.valueOf(SnowflakeUtil.nextId()),
+                email,
+                email,
+                Role.USER
+        ));
+    }
+
+    @DisplayName("동일 유저가 4개째의 이메일 전송 요청을 보내는 순간부터 오류를 발생시킨다")
+    @Test
+    void test1() throws Exception {
+        HappypillUser user = generateTestUser();
+        UserContext userContext = SecurityUserContext.from(user.getUserId());
+        EmailVerificationRequest request = new EmailVerificationRequest(faker.internet().emailAddress());
+
+        service.sendEmailVerificationCode(userContext, request);
+        service.sendEmailVerificationCode(userContext, request);
+        service.sendEmailVerificationCode(userContext, request);
+
+        assertThatThrownBy(() -> service.sendEmailVerificationCode(userContext, request))
+                .isInstanceOfSatisfying(
+                        BusinessException.class,
+                        e -> assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.EMAIL_REQUEST_COUNT_EXCEED)
+                );
+    }
+
+    @DisplayName("이메일 검증에 성공하면 유저의 알림받을 이메일이 변경된다.")
+    @Test
+    void test2() throws Exception {
+        HappypillUser user = generateTestUser();
+        UserContext userContext = SecurityUserContext.from(user.getUserId());
+        String verifyCode = faker.number().digits(6);
+        UserNotifyEmailUpdateRequest request = new UserNotifyEmailUpdateRequest(verifyCode, faker.internet().emailAddress());
+        emailVerificationRedisRepository.saveVerificationCode(userContext.getId(), request.notifyEmail(), verifyCode, Duration.ofMinutes(1L));
+
+        service.verifyAndUpdateUserNotifyEmail(userContext, request);
+
+        assertThat(user.getNotifyEmail()).isEqualTo(request.notifyEmail());
+    }
+
+    @DisplayName("이메일 검증에 실패하면 오류가 발생한다")
+    @Test
+    void test3() throws Exception {
+
+        HappypillUser user = generateTestUser();
+        UserContext userContext = SecurityUserContext.from(user.getUserId());
+        UserNotifyEmailUpdateRequest request = new UserNotifyEmailUpdateRequest("00000", "hello@google.com");
+
+        assertThatThrownBy(() -> service.verifyAndUpdateUserNotifyEmail(userContext, request))
+                .isInstanceOfSatisfying(
+                        BusinessException.class,
+                        e -> assertThat(e.getExceptionCode()).isEqualTo(ExceptionCode.EMAIL_VERIFICATION_CODE_NOT_FOUND)
+                );
+    }
+
+
+}

--- a/src/test/java/com/happypill/application/service/user/UserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/user/UserServiceTest.java
@@ -9,6 +9,7 @@ import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import com.happypill.application.service.IntegrationTestSupport;
+import com.happypill.application.service.user.email.EmailVerificationRedisRepository;
 import com.happypill.application.service.user.request.EmailVerificationRequest;
 import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
 import com.happypill.application.util.SnowflakeUtil;


### PR DESCRIPTION
# 티켓
Hp-73

# 설명
- 스프링 시큐리티 `ROLE_` 프리픽스 사용으로 변경
- redis 및 testcontainer redis 도입
- 이메일 검증 코드 전송 및 확인 구현

추가: redis repository를 어디에 넣어야 할지 확인 필요.
 

## 타입
- [x] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
redis testcontainer를 이용해 테스트 작성

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다