### PR TITLE
HP-87 : [관리자] 회원 정보 삭제 endpoint

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
@@ -40,4 +40,9 @@ public class AdminUserController {
                                               @Valid @RequestBody AdminUserUpdateRequest request){
         return adminUserService.updateUserProfile(userId, request);
     }
+
+    @DeleteMapping("/{userId}")
+    public void deleteUser(@PathVariable Long userId) {
+        adminUserService.deleteUser(userId);
+    }
 }

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -55,4 +55,8 @@ public class HappypillUser extends BaseEntity {
     public void changeNotifyEmail(String notifyEmail) {
         this.notifyEmail = notifyEmail;
     }
+
+    public void deleteUser(){
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminUserService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminUserService.java
@@ -50,6 +50,13 @@ public class AdminUserService {
         return AdminUserDetailResponse.from(user);
     }
 
+    @Transactional
+    public void deleteUser(Long userId) {
+        HappypillUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+        user.deleteUser();
+    }
+
     private void updateNickname(HappypillUser user, AdminUserUpdateRequest request){
         String newNickname = request.nickName();
         if(newNickname != null && !newNickname.isBlank()){

--- a/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
@@ -160,4 +160,32 @@ class AdminUserServiceTest {
         assertThat(updatedUser.getNickName()).isEqualTo(UPDATED_NICKNAME);
         assertThat(updatedUser.getNotifyEmail()).isEqualTo(UPDATED_NOTIFY_EMAIL);
     }
+
+    @Test
+    @DisplayName("[회원 정보 삭제] 경로변수의 userId 가 존재하지 않는 회원일 경우 예외를 반환한다.")
+    void deleteUser_1() {
+        //given
+        HappypillUser savedUser = generateTestUser();
+        userRepository.save(savedUser);
+
+        //when //then
+        assertThatThrownBy(() -> adminUserService.deleteUser(1000L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("[회원 정보 삭제] 경로변수의 userId 가 존재하는 회원일 경우 isDeleted 필드는 true 로 변환된다.")
+    void deleteUser_2() {
+        //given
+        HappypillUser savedUser = generateTestUser();
+        userRepository.save(savedUser);
+
+        //when
+        adminUserService.deleteUser(savedUser.getUserId());
+        HappypillUser updatedUser = userRepository.findById(savedUser.getUserId()).orElseThrow();
+
+        //then
+        assertThat(updatedUser.isDeleted()).isTrue();
+    }
 }


### PR DESCRIPTION
# 티켓
HP-87

# 설명
1. [관리자] 회원 정보 삭제 endpoint 로직 생성 (실제 리소스 삭제가 아닌 isDeleted 필드만 true 로 변경)

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합테스트 및 postman 으로 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다