### PR TITLE
HP-113 : SwaggerConfig 에서 Profile 부분 삭제

### DIFF
--- a/src/main/java/com/happypill/application/swagger/SwaggerConfig.java
+++ b/src/main/java/com/happypill/application/swagger/SwaggerConfig.java
@@ -15,11 +15,9 @@ import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 @Configuration
-@Profile("!prod")
 public class SwaggerConfig {
 
     @Bean


### PR DESCRIPTION
# 티켓
HP-113

# 설명
SwaggerConfig에서 @Profile(!prod) 를 적용하여 프로덕션 환경에서 보이지 않는 문제 
-> @Profile(!prod) 삭제하여 해결

## 타입
- [x] 버그
- [ ] 작업
- [ ] 기능 향상

# 테스트 방법
테스트 없음

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [ ] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다