### PR TITLE
HP-106 : [관리자] 특정 카테고리 조회

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
@@ -3,6 +3,7 @@ package com.happypill.api.controller.admin;
 import com.happypill.application.pagination.CustomPage;
 import com.happypill.application.service.admin.AdminCategoryService;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
+import com.happypill.application.service.admin.response.AdminCategoryInfoResponse;
 import com.happypill.application.service.admin.response.AdminCategoryListResponse;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,5 +44,11 @@ public class AdminCategoryController {
         adminCategoryService.saveCategories(adminCategoryCreateRequestList);
 
         return ResponseEntity.created(URI.create("/api/admin/categories")).build();
+    }
+
+    @GetMapping("{categoryId}")
+    //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
+    public AdminCategoryInfoResponse getCategoryDetail(@PathVariable Long categoryId){
+        return adminCategoryService.getCategoryDetails(categoryId);
     }
 }

--- a/src/main/java/com/happypill/application/repository/categoryinfo/CategoryInfoRepository.java
+++ b/src/main/java/com/happypill/application/repository/categoryinfo/CategoryInfoRepository.java
@@ -25,4 +25,7 @@ public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Long
             FROM CategoryInfo ci
             """)
     List<CategoryInfo> findAllCategoryInfo();
+
+    @Query("SELECT ci FROM CategoryInfo ci WHERE ci.category.categoryId = :categoryId")
+    List<CategoryInfo> getAllCategoryInfosById(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
@@ -10,6 +10,7 @@ import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
 import com.happypill.application.service.admin.request.AdminCategoryInfoRequest;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
+import com.happypill.application.service.admin.response.AdminCategoryInfoResponse;
 import com.happypill.application.service.admin.response.AdminCategoryListResponse;
 import com.happypill.application.util.SnowflakeUtil;
 import lombok.RequiredArgsConstructor;
@@ -70,5 +71,15 @@ public class AdminCategoryService {
 
         categoryRepository.saveAll(categories);
         categoryInfoRepository.saveAll(categoryInfos);
+    }
+
+    @Transactional(readOnly = true)
+    public AdminCategoryInfoResponse getCategoryDetails(Long categoryId){
+        Category category = categoryRepository.findByCategoryId(categoryId)
+                .orElseThrow(() -> new BusinessException(ExceptionCode.CATEGORY_NOT_FOUND));
+
+        List<CategoryInfo> categoryInfoList = categoryInfoRepository.getAllCategoryInfosById(category.getCategoryId());
+
+        return AdminCategoryInfoResponse.fromCategoryAndInfos(category, categoryInfoList);
     }
 }

--- a/src/main/java/com/happypill/application/service/admin/response/AdminCategoryInfoResponse.java
+++ b/src/main/java/com/happypill/application/service/admin/response/AdminCategoryInfoResponse.java
@@ -1,0 +1,27 @@
+package com.happypill.application.service.admin.response;
+
+import com.happypill.application.entity.Category;
+import com.happypill.application.entity.CategoryInfo;
+import com.happypill.application.service.category.dto.response.CategoryInfoResponse;
+
+import java.util.List;
+
+public record AdminCategoryInfoResponse(
+        String categoryId,
+        String thumbnailUrl,
+        String bannerUrl,
+        List<CategoryInfoResponse> categoryInfo
+) {
+    public static AdminCategoryInfoResponse fromCategoryAndInfos(Category category, List<CategoryInfo> categoryInfos){
+        List<CategoryInfoResponse> categoryInfoList = categoryInfos.stream()
+                .map(CategoryInfoResponse::fromEntity)
+                .toList();
+
+        return new AdminCategoryInfoResponse(
+                category.getCategoryId().toString(),
+                category.getThumbnailUrl(),
+                category.getBannerUrl(),
+                categoryInfoList
+        );
+    }
+}

--- a/src/main/java/com/happypill/application/service/category/dto/response/CategoryInfoResponse.java
+++ b/src/main/java/com/happypill/application/service/category/dto/response/CategoryInfoResponse.java
@@ -1,0 +1,20 @@
+package com.happypill.application.service.category.dto.response;
+
+import com.happypill.application.entity.CategoryInfo;
+import com.happypill.application.entity.enums.Language;
+
+public record CategoryInfoResponse(
+        String categoryInfoId,
+        Language language,
+        String name,
+        String description
+) {
+    public static CategoryInfoResponse fromEntity(CategoryInfo categoryInfo){
+        return new CategoryInfoResponse(
+                categoryInfo.getCategoryInfoId().toString(),
+                categoryInfo.getLanguage(),
+                categoryInfo.getName(),
+                categoryInfo.getDescription()
+        );
+    }
+}

--- a/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
@@ -3,11 +3,14 @@ package com.happypill.application.service.admin;
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
 import com.happypill.application.entity.enums.Language;
+import com.happypill.application.exception.custom.ExceptionCode;
+import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.pagination.CustomPage;
 import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
 import com.happypill.application.service.admin.request.AdminCategoryInfoRequest;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
+import com.happypill.application.service.admin.response.AdminCategoryInfoResponse;
 import com.happypill.application.service.admin.response.AdminCategoryListResponse;
 import com.happypill.application.util.SnowflakeUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -100,5 +104,42 @@ class AdminCategoryServiceTest {
         assertThat(categoryInfos.get(0).getDescription()).isEqualTo(categoryInfoRequests.get(0).description());
         assertThat(categoryInfos.get(1).getName()).isEqualTo(categoryInfoRequests.get(1).name());
         assertThat(categoryInfos.get(1).getDescription()).isEqualTo(categoryInfoRequests.get(1).description());
+    }
+
+    @Test
+    @DisplayName("[특정 카테고리 조회] 경로변수의 CategoryId 가 존재하지 않으면 에러가 발생한다.")
+    void getCategoryDetails_1(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        List<CategoryInfo> categoryInfoList = List.of(
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", "설명_KO", category),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", "설명_EN", category)
+        );
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryInfoList);
+
+        //when //then
+        assertThatThrownBy(()->adminCategoryService.getCategoryDetails(1000L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.CATEGORY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("[특정 카테고리 조회] 경로변수의 CategoryId 가 존재하면 200 상태코드와 함께 AdminCategoryInfoResponse 를 반환한다.")
+    void getCategoryDetails_2(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        List<CategoryInfo> categoryInfoList = List.of(
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", "설명_KO", category),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", "설명_EN", category)
+        );
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryInfoList);
+
+        //when
+        AdminCategoryInfoResponse response = adminCategoryService.getCategoryDetails(category.getCategoryId());
+
+        //then
+        assertThat(response.categoryId()).isEqualTo(String.valueOf(category.getCategoryId()));
     }
 }


### PR DESCRIPTION
# 티켓
HP-106

# 설명
1. [관리자페이지] 특정 카테고리 조회 endpoint 생성
2. AdminCategoryInfoResponse, CategoryInfoResponse 2개의 dto 생성

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합 테스트 및 postman 으로 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다