### PR TITLE
HP-92/Order-payment-detail

### DIFF
--- a/src/main/java/com/happypill/api/controller/order/OrderController.java
+++ b/src/main/java/com/happypill/api/controller/order/OrderController.java
@@ -6,6 +6,7 @@ import com.happypill.application.service.order.OrderService;
 import com.happypill.application.service.order.request.OrderCreateRequest;
 import com.happypill.application.service.order.request.OrderPaymentCompleteRequest;
 import com.happypill.application.service.order.response.OrderResponse;
+import com.happypill.application.service.order.response.PaymentConfirmResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,8 +27,8 @@ public class OrderController {
     }
 
     @PostMapping("/api/order/payment-confirm")
-    public void confirmPayment(@HappypillUser UserContext userContext, @RequestBody @Valid OrderPaymentCompleteRequest request) {
-        orderService.confirmPayment(request);
+    public PaymentConfirmResponse confirmPayment(@HappypillUser UserContext userContext, @RequestBody @Valid OrderPaymentCompleteRequest request) {
+        return orderService.confirmPayment(request);
     }
 
 }

--- a/src/main/java/com/happypill/application/service/order/OrderService.java
+++ b/src/main/java/com/happypill/application/service/order/OrderService.java
@@ -8,10 +8,11 @@ import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import com.happypill.application.repository.order.OrderRepository;
 import com.happypill.application.repository.product.ProductRepository;
-import com.happypill.application.service.order.payment.PortonePaymentClient;
+import com.happypill.application.service.order.payment.PPaymentClient;
 import com.happypill.application.service.order.request.OrderCreateRequest;
 import com.happypill.application.service.order.request.OrderPaymentCompleteRequest;
 import com.happypill.application.service.order.response.OrderResponse;
+import com.happypill.application.service.order.response.PaymentConfirmResponse;
 import com.happypill.application.util.SnowflakeUtil;
 import io.portone.sdk.server.payment.PaidPayment;
 import io.portone.sdk.server.payment.Payment;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +40,7 @@ public class OrderService {
 
     private final HappypillUserRepository userRepository;
 
-    private final PortonePaymentClient portonePaymentClient;
+    private final PPaymentClient pPaymentClient;
 
     @Transactional
     public OrderResponse createOrder(UserContext userContext, OrderCreateRequest request) {
@@ -105,7 +107,7 @@ public class OrderService {
     }
 
     @Transactional
-    public void confirmPayment(OrderPaymentCompleteRequest request) {
+    public PaymentConfirmResponse confirmPayment(OrderPaymentCompleteRequest request) {
         String paymentUid = request.paymentUid();
         PaidPayment paidPayment = getPayment(paymentUid);
 
@@ -120,10 +122,18 @@ public class OrderService {
 
         order.complete();
 
+        return new PaymentConfirmResponse(
+                String.valueOf(order.getId()),
+                order.getPaymentUid(),
+                paidPayment.getCurrency().getValue(),
+                order.getTotalPrice(),
+                ZonedDateTime.from(paidPayment.getPaidAt()),
+                paidPayment.getMethod()
+        );
     }
 
     PaidPayment getPayment(String paymentUid) {
-        Payment rawpayment = portonePaymentClient.getPaymentInfo(paymentUid);
+        Payment rawpayment = pPaymentClient.getPayment(paymentUid);
         if (rawpayment instanceof PaidPayment paidPayment) {
             return paidPayment;
         } else {

--- a/src/main/java/com/happypill/application/service/order/payment/NoOpsPPaymentClient.java
+++ b/src/main/java/com/happypill/application/service/order/payment/NoOpsPPaymentClient.java
@@ -1,0 +1,13 @@
+package com.happypill.application.service.order.payment;
+
+import io.portone.sdk.server.payment.Payment;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NoOpsPPaymentClient implements PPaymentClient {
+    @Override
+    public Payment getPayment(String paymentUid) {
+        log.info("paymentUid = {}", paymentUid);
+        return null;
+    }
+}

--- a/src/main/java/com/happypill/application/service/order/payment/PPaymentClient.java
+++ b/src/main/java/com/happypill/application/service/order/payment/PPaymentClient.java
@@ -1,0 +1,10 @@
+package com.happypill.application.service.order.payment;
+
+import io.portone.sdk.server.payment.Payment;
+
+public interface PPaymentClient {
+
+    Payment getPayment(String paymentUid);
+}
+
+

--- a/src/main/java/com/happypill/application/service/order/payment/PortonePPaymentClient.java
+++ b/src/main/java/com/happypill/application/service/order/payment/PortonePPaymentClient.java
@@ -8,16 +8,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class PortonePaymentClient {
+public class PortonePPaymentClient implements PPaymentClient {
 
     private final PaymentClient portone;
 
     @Autowired
-    public PortonePaymentClient(PortOneProperties properties) {
+    public PortonePPaymentClient(PortOneProperties properties) {
         this.portone = new PaymentClient(properties.apiSecret(), "https://api.portone.io", properties.storeId());
     }
 
-    public Payment getPaymentInfo(String paymentUid) {
+    public Payment getPayment(String paymentUid) {
         try {
             return portone.getPayment(paymentUid)
                     .get();

--- a/src/main/java/com/happypill/application/service/order/response/PaymentConfirmResponse.java
+++ b/src/main/java/com/happypill/application/service/order/response/PaymentConfirmResponse.java
@@ -1,0 +1,13 @@
+package com.happypill.application.service.order.response;
+
+import java.time.ZonedDateTime;
+
+public record PaymentConfirmResponse(
+        String orderId,
+        String paymentUid,
+        String currency,
+        Integer totalPrice,
+        ZonedDateTime paidAt,
+        Object paymentProvider
+) {
+}


### PR DESCRIPTION
# 티켓
HP-92

# 설명
인터페이스 분리 및, 결제수단 정보 리턴
따로 도메인 객체로 분리하지는 않고, 포트윈 응답 객체 그대로 사용.

결제 확인시에 
결제수단정보(예: 카카오페이간편결제등)를 따로 반환하도록 변경했으나
전부 파악하지 못해 그냥 객체로 넘김

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다