### PR TITLE
Hp 92/order payment detail

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.retry:spring-retry")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/src/main/java/com/happypill/api/controller/order/OrderController.java
+++ b/src/main/java/com/happypill/api/controller/order/OrderController.java
@@ -6,6 +6,7 @@ import com.happypill.application.service.order.OrderService;
 import com.happypill.application.service.order.request.OrderCreateRequest;
 import com.happypill.application.service.order.request.OrderPaymentCompleteRequest;
 import com.happypill.application.service.order.response.OrderResponse;
+import com.happypill.application.service.order.response.PaymentConfirmResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,8 +27,8 @@ public class OrderController {
     }
 
     @PostMapping("/api/order/payment-confirm")
-    public void confirmPayment(@HappypillUser UserContext userContext, @RequestBody @Valid OrderPaymentCompleteRequest request) {
-        orderService.confirmPayment(request);
+    public PaymentConfirmResponse confirmPayment(@HappypillUser UserContext userContext, @RequestBody @Valid OrderPaymentCompleteRequest request) {
+        return orderService.confirmPayment(request);
     }
 
 }

--- a/src/main/java/com/happypill/application/entity/Product.java
+++ b/src/main/java/com/happypill/application/entity/Product.java
@@ -37,13 +37,16 @@ public class Product extends BaseEntity<Long> {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @Version
+    private Long version;
+
 
     public static Product of(Long productId, Integer price, Integer stock, boolean isAvailable, String thumbnailUrl, boolean isDeleted, Category category) {
-        return new Product(productId, price, stock, isAvailable, thumbnailUrl, isDeleted, category);
+        return new Product(productId, price, stock, isAvailable, thumbnailUrl, isDeleted, category, null);
     }
 
     public static Product of(Long productId, Integer price, Integer stock, String thumbnailUrl, Category category) {
-        return new Product(productId, price, stock, true, thumbnailUrl, false, category);
+        return new Product(productId, price, stock, true, thumbnailUrl, false, category, null);
     }
 
     public void decreaseStock(int count) {

--- a/src/main/java/com/happypill/application/repository/product/ProductRepository.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepository.java
@@ -56,9 +56,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             """)
     List<Product> findAllProducts();
 
+    @Deprecated
     /**
      * for no key update
      * GPT는 ORDER BY 사용을 권장하나, 제외해도 실제로 데드락 발생 X
+     * 낙관적 락으로 변경
      **/
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
@@ -68,4 +70,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             ORDER BY p.id
             """)
     List<Product> findAllByProductIdsWithPessimisticLock(@Param("productIds") List<Long> productIds);
+
+    @Query("""
+            SELECT p
+            FROM Product p
+            WHERE p.id IN :productIds
+            """)
+    List<Product> findAllByIdIn(@Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/happypill/application/service/order/OrderService.java
+++ b/src/main/java/com/happypill/application/service/order/OrderService.java
@@ -18,6 +18,9 @@ import io.portone.sdk.server.payment.PaidPayment;
 import io.portone.sdk.server.payment.Payment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,8 +46,13 @@ public class OrderService {
     private final PPaymentClient pPaymentClient;
 
     @Transactional
+    @Retryable(
+            retryFor = ObjectOptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
     public OrderResponse createOrder(UserContext userContext, OrderCreateRequest request) {
-        Map<Long, Product> productMap = getProductMapWithLock(request);
+        Map<Long, Product> productMap = getOrderProductMap(request);
         List<OrderLine> orderLines = decreaseStockAndGetOrderLines(request, productMap);
 
         HappypillUser orderedUser = userRepository.findById(userContext.getId())
@@ -61,7 +69,6 @@ public class OrderService {
                 orderLines
         ));
 
-
         return OrderResponse.from(order);
     }
 
@@ -69,9 +76,7 @@ public class OrderService {
         List<OrderLine> orderLines = new ArrayList<>();
         for (var o : request.orderLineCreateRequests()) {
             Product orderProduct = ProductMap.get(o.productId());
-            if (o.month() > orderProduct.getStock()) {
-                throw new RuntimeException("재고불가");
-            }
+
             orderProduct.decreaseStock(o.month());
 
             OrderLine orderLine = OrderLine.create(
@@ -86,11 +91,11 @@ public class OrderService {
         return orderLines;
     }
 
-    private Map<Long, Product> getProductMapWithLock(OrderCreateRequest request) {
+    private Map<Long, Product> getOrderProductMap(OrderCreateRequest request) {
         List<Long> productIds = request.orderLineCreateRequests().stream()
                 .map(OrderCreateRequest.OrderLineCreateRequest::productId)
                 .toList();
-        Map<Long, Product> ProductMap = productRepository.findAllByProductIdsWithPessimisticLock(productIds).stream()
+        Map<Long, Product> ProductMap = productRepository.findAllByIdIn(productIds).stream()
                 .collect(Collectors.toMap(Product::getId, Function.identity()));
         if (productIds.size() != ProductMap.size()) {
             throw new RuntimeException("유효하지 않은 요청");

--- a/src/main/java/com/happypill/application/service/order/OrderService.java
+++ b/src/main/java/com/happypill/application/service/order/OrderService.java
@@ -8,10 +8,11 @@ import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import com.happypill.application.repository.order.OrderRepository;
 import com.happypill.application.repository.product.ProductRepository;
-import com.happypill.application.service.order.payment.PortonePaymentClient;
+import com.happypill.application.service.order.payment.PPaymentClient;
 import com.happypill.application.service.order.request.OrderCreateRequest;
 import com.happypill.application.service.order.request.OrderPaymentCompleteRequest;
 import com.happypill.application.service.order.response.OrderResponse;
+import com.happypill.application.service.order.response.PaymentConfirmResponse;
 import com.happypill.application.util.SnowflakeUtil;
 import io.portone.sdk.server.payment.PaidPayment;
 import io.portone.sdk.server.payment.Payment;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +40,7 @@ public class OrderService {
 
     private final HappypillUserRepository userRepository;
 
-    private final PortonePaymentClient portonePaymentClient;
+    private final PPaymentClient pPaymentClient;
 
     @Transactional
     public OrderResponse createOrder(UserContext userContext, OrderCreateRequest request) {
@@ -105,7 +107,7 @@ public class OrderService {
     }
 
     @Transactional
-    public void confirmPayment(OrderPaymentCompleteRequest request) {
+    public PaymentConfirmResponse confirmPayment(OrderPaymentCompleteRequest request) {
         String paymentUid = request.paymentUid();
         PaidPayment paidPayment = getPayment(paymentUid);
 
@@ -120,10 +122,18 @@ public class OrderService {
 
         order.complete();
 
+        return new PaymentConfirmResponse(
+                String.valueOf(order.getId()),
+                order.getPaymentUid(),
+                paidPayment.getCurrency().getValue(),
+                order.getTotalPrice(),
+                ZonedDateTime.from(paidPayment.getPaidAt()),
+                paidPayment.getMethod()
+        );
     }
 
     PaidPayment getPayment(String paymentUid) {
-        Payment rawpayment = portonePaymentClient.getPaymentInfo(paymentUid);
+        Payment rawpayment = pPaymentClient.getPayment(paymentUid);
         if (rawpayment instanceof PaidPayment paidPayment) {
             return paidPayment;
         } else {

--- a/src/main/java/com/happypill/application/service/order/payment/NoOpsPPaymentClient.java
+++ b/src/main/java/com/happypill/application/service/order/payment/NoOpsPPaymentClient.java
@@ -1,0 +1,13 @@
+package com.happypill.application.service.order.payment;
+
+import io.portone.sdk.server.payment.Payment;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NoOpsPPaymentClient implements PPaymentClient {
+    @Override
+    public Payment getPayment(String paymentUid) {
+        log.info("paymentUid = {}", paymentUid);
+        return null;
+    }
+}

--- a/src/main/java/com/happypill/application/service/order/payment/PPaymentClient.java
+++ b/src/main/java/com/happypill/application/service/order/payment/PPaymentClient.java
@@ -1,0 +1,10 @@
+package com.happypill.application.service.order.payment;
+
+import io.portone.sdk.server.payment.Payment;
+
+public interface PPaymentClient {
+
+    Payment getPayment(String paymentUid);
+}
+
+

--- a/src/main/java/com/happypill/application/service/order/payment/PortonePPaymentClient.java
+++ b/src/main/java/com/happypill/application/service/order/payment/PortonePPaymentClient.java
@@ -8,16 +8,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class PortonePaymentClient {
+public class PortonePPaymentClient implements PPaymentClient {
 
     private final PaymentClient portone;
 
     @Autowired
-    public PortonePaymentClient(PortOneProperties properties) {
+    public PortonePPaymentClient(PortOneProperties properties) {
         this.portone = new PaymentClient(properties.apiSecret(), "https://api.portone.io", properties.storeId());
     }
 
-    public Payment getPaymentInfo(String paymentUid) {
+    public Payment getPayment(String paymentUid) {
         try {
             return portone.getPayment(paymentUid)
                     .get();

--- a/src/main/java/com/happypill/application/service/order/response/PaymentConfirmResponse.java
+++ b/src/main/java/com/happypill/application/service/order/response/PaymentConfirmResponse.java
@@ -1,0 +1,13 @@
+package com.happypill.application.service.order.response;
+
+import java.time.ZonedDateTime;
+
+public record PaymentConfirmResponse(
+        String orderId,
+        String paymentUid,
+        String currency,
+        Integer totalPrice,
+        ZonedDateTime paidAt,
+        Object paymentProvider
+) {
+}

--- a/src/main/java/com/happypill/infra/retry/LoggingRetryListener.java
+++ b/src/main/java/com/happypill/infra/retry/LoggingRetryListener.java
@@ -1,0 +1,22 @@
+package com.happypill.infra.retry;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class LoggingRetryListener implements RetryListener {
+    @Override
+    public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+        int retryCount = context.getRetryCount(); // 0부터 시작
+        log.info("Retry attempt {} failed", retryCount + 1, throwable);
+    }
+
+    @Override
+    public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+        log.error("retry attempt fail", throwable);
+    }
+}

--- a/src/main/java/com/happypill/infra/retry/RetryConfig.java
+++ b/src/main/java/com/happypill/infra/retry/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.happypill.infra.retry;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}


### PR DESCRIPTION
# 티켓
Hp-92

# 설명
product stock 낙관적 락 방식으로 변경
결제 성공시, 관련정보를 담게 변경
결제 정보를 가저오는 클래스 인터페이스로 분리
정확한 주문방법 (예: 카카오페이)를 찾기 어려워 Object로 넘김

## 타입
- [ ] 버그
- [x] 작업
- [x] 기능 향상

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다