### PR TITLE
HP-104 : [관리자] 카테고리 수정 endpoint

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
@@ -3,6 +3,7 @@ package com.happypill.api.controller.admin;
 import com.happypill.application.pagination.CustomPage;
 import com.happypill.application.service.admin.AdminCategoryService;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
+import com.happypill.application.service.admin.request.AdminCategoryUpdateRequest;
 import com.happypill.application.service.admin.response.AdminCategoryInfoResponse;
 import com.happypill.application.service.admin.response.AdminCategoryListResponse;
 import com.happypill.application.service.category.dto.response.CategoryNamesResponse;
@@ -58,5 +59,12 @@ public class AdminCategoryController {
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public List<CategoryNamesResponse> getCategoryNames(){
         return adminCategoryService.getCategoryNames();
+    }
+
+    @PatchMapping("/{categoryId}")
+    //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
+    public AdminCategoryInfoResponse updateCategory(@PathVariable Long categoryId,
+                                                    @Valid @RequestBody AdminCategoryUpdateRequest request) {
+        return adminCategoryService.updateCategory(categoryId, request);
     }
 }

--- a/src/main/java/com/happypill/application/entity/Category.java
+++ b/src/main/java/com/happypill/application/entity/Category.java
@@ -30,4 +30,9 @@ public class Category extends BaseEntity<Long> {
     public static Category of(Long categoryId, String thumbnailUrl, String bannerUrl) {
         return new Category(categoryId, thumbnailUrl, bannerUrl);
     }
+
+    public void update(String thumbnailUrl, String bannerUrl){
+        this.thumbnailUrl = thumbnailUrl;
+        this.bannerUrl = bannerUrl;
+    }
 }

--- a/src/main/java/com/happypill/application/entity/CategoryInfo.java
+++ b/src/main/java/com/happypill/application/entity/CategoryInfo.java
@@ -38,4 +38,9 @@ public class CategoryInfo extends BaseEntity<Long> {
     public static CategoryInfo of(Long categoryInfoId, Language language, String name, String description, Category category) {
         return new CategoryInfo(categoryInfoId, language, name, description, category);
     }
+
+    public void update(String name, String description){
+        this.name = name;
+        this.description = description;
+    }
 }

--- a/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
+++ b/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
@@ -25,7 +25,10 @@ public enum ExceptionCode {
     EMAIL_VERIFICATION_CODE_NOT_FOUND(BAD_REQUEST, "인증 코드가 만료되었거나 존재하지 않습니다"),
 
     // 카테고리
-    CATEGORY_NOT_FOUND(NOT_FOUND, "해당 카테고리를 찾을 수 없습니다.");
+    CATEGORY_NOT_FOUND(NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
+
+    // 카테고리 정보
+    CATEGORY_INFO_NOT_FOUND(NOT_FOUND, "해당 카테고리 정보를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/happypill/application/repository/categoryinfo/CategoryInfoRepository.java
+++ b/src/main/java/com/happypill/application/repository/categoryinfo/CategoryInfoRepository.java
@@ -1,5 +1,6 @@
 package com.happypill.application.repository.categoryinfo;
 
+import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
 import com.happypill.application.entity.enums.Language;
 import org.springframework.data.domain.Page;
@@ -36,4 +37,6 @@ public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Long
             ORDER BY c.id
             """)
     List<CategoryInfo> findAllCategoryInfoOrderById();
+
+    List<CategoryInfo> findAllByCategory(Category category);
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
@@ -107,13 +107,16 @@ public class AdminCategoryService {
 
         category.update(request.thumbnailUrl(), request.bannerUrl());
 
+        List<CategoryInfo> categoryInfoList = categoryInfoRepository.getAllCategoryInfosById(category.getId());
+
         for(CategoryInfoRequest dto : request.categoryInfos()){
             if(dto.categoryInfoId() == null){ //만약 등록되어 있지 않은 CategoryInfo 가 작성되는 경우 객체 생성
                 categoryInfoRepository.save(CategoryInfo.of(SnowflakeUtil.nextId(), dto.language(), dto.name(), dto.description(), category));
             }
             else{
-                CategoryInfo categoryInfo = categoryInfoRepository.findById(dto.categoryInfoId())
-                        .filter(info -> info.getCategory().equals(category))
+                CategoryInfo categoryInfo = categoryInfoList.stream()
+                        .filter(ci -> ci.getId().equals(dto.categoryInfoId()))
+                        .findFirst()
                         .orElseThrow(() -> new BusinessException(ExceptionCode.CATEGORY_INFO_NOT_FOUND));
 
                 categoryInfo.update(dto.name(), dto.description());

--- a/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
@@ -10,9 +10,11 @@ import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
 import com.happypill.application.service.admin.request.AdminCategoryInfoRequest;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
+import com.happypill.application.service.admin.request.AdminCategoryUpdateRequest;
 import com.happypill.application.service.admin.response.AdminCategoryInfoResponse;
 import com.happypill.application.service.admin.response.AdminCategoryListResponse;
 import com.happypill.application.service.category.dto.response.CategoryNamesResponse;
+import com.happypill.application.service.category.request.CategoryInfoRequest;
 import com.happypill.application.util.SnowflakeUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -97,5 +99,26 @@ public class AdminCategoryService {
         return grouped.entrySet().stream()
                 .map(entry -> CategoryNamesResponse.fromCategoryIdAndInfos(entry.getKey(), entry.getValue()))
                 .toList();
+    }
+
+    public AdminCategoryInfoResponse updateCategory(Long categoryId, AdminCategoryUpdateRequest request){
+        Category category = this.categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new BusinessException(ExceptionCode.CATEGORY_NOT_FOUND));
+
+        category.update(request.thumbnailUrl(), request.bannerUrl());
+
+        for(CategoryInfoRequest dto : request.categoryInfos()){
+            if(dto.categoryInfoId() == null){ //만약 등록되어 있지 않은 CategoryInfo 가 작성되는 경우 객체 생성
+                categoryInfoRepository.save(CategoryInfo.of(SnowflakeUtil.nextId(), dto.language(), dto.name(), dto.description(), category));
+            }
+            else{
+                CategoryInfo categoryInfo = categoryInfoRepository.findById(dto.categoryInfoId())
+                        .filter(info -> info.getCategory().equals(category))
+                        .orElseThrow(() -> new BusinessException(ExceptionCode.CATEGORY_INFO_NOT_FOUND));
+
+                categoryInfo.update(dto.name(), dto.description());
+            }
+        }
+        return AdminCategoryInfoResponse.fromCategoryAndInfos(category, categoryInfoRepository.findAllByCategory(category));
     }
 }

--- a/src/main/java/com/happypill/application/service/admin/request/AdminCategoryUpdateRequest.java
+++ b/src/main/java/com/happypill/application/service/admin/request/AdminCategoryUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.happypill.application.service.admin.request;
+
+import com.happypill.application.service.category.request.CategoryInfoRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record AdminCategoryUpdateRequest(
+
+        @NotNull(message = "썸네일사진은 필수 입력란입니다")
+        String thumbnailUrl,
+
+        @NotNull(message = "배너사진은 필수 입력란입니다")
+        String bannerUrl,
+
+        @Size(min = 1, message = "카테고리 정보는 필수 입력란입니다")
+        List<@Valid CategoryInfoRequest> categoryInfos
+) {
+}

--- a/src/main/java/com/happypill/application/service/category/request/CategoryInfoRequest.java
+++ b/src/main/java/com/happypill/application/service/category/request/CategoryInfoRequest.java
@@ -1,0 +1,20 @@
+package com.happypill.application.service.category.request;
+
+import com.happypill.application.entity.enums.Language;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record CategoryInfoRequest(
+
+        Long categoryInfoId,
+
+        @NotNull(message = "언어는 필수 입력란입니다")
+        Language language,
+
+        @NotEmpty(message = "이름은 필수 입력란입니다")
+        String name,
+
+        @NotEmpty(message = "설명란은 필수 입력란입니다")
+        String description
+) {
+}

--- a/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
@@ -10,9 +10,11 @@ import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
 import com.happypill.application.service.admin.request.AdminCategoryInfoRequest;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
+import com.happypill.application.service.admin.request.AdminCategoryUpdateRequest;
 import com.happypill.application.service.admin.response.AdminCategoryInfoResponse;
 import com.happypill.application.service.admin.response.AdminCategoryListResponse;
 import com.happypill.application.service.category.dto.response.CategoryNamesResponse;
+import com.happypill.application.service.category.request.CategoryInfoRequest;
 import com.happypill.application.util.SnowflakeUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -162,5 +164,77 @@ class AdminCategoryServiceTest {
         //then
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).categoryId()).isEqualTo(String.valueOf(category.getId()));
+    }
+
+    @Test
+    @DisplayName("[카테고리 수정] 경로 변수의 categoryId 가 존재하지 않는 Category 면 예외가 발생한다.")
+    void updateCategory_1(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        List<CategoryInfo> categoryInfoList = List.of(
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+        );
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryInfoList);
+
+        List<CategoryInfoRequest> infoRequests = List.of(
+                new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO", "변경된_설명_KO"),
+                new CategoryInfoRequest(2L, Language.EN, "변경된_카테고리명_EN", "변경된_설명_EN")
+        );
+        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
+
+        //when //then
+        assertThatThrownBy(() -> adminCategoryService.updateCategory(0L, updateRequest))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.CATEGORY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("[카테고리 수정] CategoryInfoRequest 의 categoryInfoId 가 category 에 속해있지 않는 값이면 예외가 발생한다.")
+    void updateCategory_2(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        List<CategoryInfo> categoryInfoList = List.of(
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+        );
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryInfoList);
+
+        List<CategoryInfoRequest> infoRequests = List.of(
+                new CategoryInfoRequest(3L, Language.KO, "변경된_카테고리명_KO", "변경된_설명_KO"),
+                new CategoryInfoRequest(4L, Language.EN, "변경된_카테고리명_EN", "변경된_설명_EN")
+        );
+        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
+
+        //when //then
+        assertThatThrownBy(() -> adminCategoryService.updateCategory(category.getId(), updateRequest))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.CATEGORY_INFO_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("[카테고리 수정] 언어가 KO로 된 CategoryInfo 만 존재할 때 EN로 된 CategoryInfo 정보를 작성할 경우 EN 으로 된 CategoryInfo 객체가 새로 생성된다.")
+    void updateCategory_3(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        CategoryInfo categoryInfo = CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category);
+
+        categoryRepository.save(category);
+        categoryInfoRepository.save(categoryInfo);
+
+        List<CategoryInfoRequest> infoRequests = List.of(
+                new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO", "변경된_설명_KO"),
+                new CategoryInfoRequest(null, Language.EN, "추가된_카테고리명_EN", "추가된_설명_EN")
+        );
+        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
+
+        //when
+        AdminCategoryInfoResponse response = adminCategoryService.updateCategory(category.getId(), updateRequest);
+        List<CategoryInfo> categoryInfos = categoryInfoRepository.findAllByCategory(category);
+
+        // then
+        assertThat(categoryInfos).hasSize(2);
     }
 }


### PR DESCRIPTION
# 티켓
HP-104

# 설명
- [관리자 페이지] 에서 카테고리를 수정하는 endpoint 생성
- 수정을 위한 dto 생성

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합테스트 및 postman 으로 데이터 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다