### PR TITLE
HP-79 LocaleContextResolver 등록

### DIFF
--- a/src/main/java/com/happypill/api/config/CustomHeaders.java
+++ b/src/main/java/com/happypill/api/config/CustomHeaders.java
@@ -1,0 +1,13 @@
+package com.happypill.api.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CustomHeaders {
+
+    public static final String LANGUAGE_HEADER = "APP_LANGUAGE";
+
+    public static final String TIMEZONE_HEADER = "APP-TIME-ZONE";
+
+}

--- a/src/main/java/com/happypill/api/config/CustomHeaders.java
+++ b/src/main/java/com/happypill/api/config/CustomHeaders.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CustomHeaders {
 
-    public static final String LANGUAGE_HEADER = "APP_LANGUAGE";
+    public static final String LANGUAGE_HEADER = "APP-LANGUAGE";
 
     public static final String TIMEZONE_HEADER = "APP-TIME-ZONE";
 

--- a/src/main/java/com/happypill/api/config/CustomQueryParameters.java
+++ b/src/main/java/com/happypill/api/config/CustomQueryParameters.java
@@ -1,0 +1,11 @@
+package com.happypill.api.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CustomQueryParameters {
+    public static final String LANGUAGE_PARAMETER = "language";
+
+    public static final String TIMEZONE_PARAMETER = "timeZone";
+}

--- a/src/main/java/com/happypill/api/config/WebConfig.java
+++ b/src/main/java/com/happypill/api/config/WebConfig.java
@@ -1,6 +1,6 @@
 package com.happypill.api.config;
 
-import com.happypill.api.config.auth.usercontext.UserContextArgumentResolver;
+import com.happypill.api.config.argumentresolver.UserContextArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;

--- a/src/main/java/com/happypill/api/config/argumentresolver/UserContextArgumentResolver.java
+++ b/src/main/java/com/happypill/api/config/argumentresolver/UserContextArgumentResolver.java
@@ -1,5 +1,6 @@
-package com.happypill.api.config.auth.usercontext;
+package com.happypill.api.config.argumentresolver;
 
+import com.happypill.api.config.auth.usercontext.HappypillUser;
 import com.happypill.application.auth.UserContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;

--- a/src/main/java/com/happypill/api/config/localeContextResolver/ContentLanguageAdvice.java
+++ b/src/main/java/com/happypill/api/config/localeContextResolver/ContentLanguageAdvice.java
@@ -1,0 +1,25 @@
+package com.happypill.api.config.localeContextResolver;
+
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@ControllerAdvice
+public class ContentLanguageAdvice implements ResponseBodyAdvice<Object> {
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        response.getHeaders().set(HttpHeaders.CONTENT_LANGUAGE, LocaleContextHolder.getLocale().toLanguageTag());
+        return body;
+    }
+}

--- a/src/main/java/com/happypill/api/config/localeContextResolver/CustomLocaleResolver.java
+++ b/src/main/java/com/happypill/api/config/localeContextResolver/CustomLocaleResolver.java
@@ -1,0 +1,70 @@
+package com.happypill.api.config.localeContextResolver;
+
+import com.happypill.api.config.CustomHeaders;
+import com.happypill.api.config.CustomQueryParameters;
+import com.happypill.application.entity.enums.Language;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import java.util.Locale;
+
+import static org.springframework.util.StringUtils.hasText;
+
+/**
+ * HappyPill 애플리케이션용 커스텀 LocaleResolver
+ * <p>
+ * 우선순위:
+ * 1. language 쿼리 파라미터
+ * 2. Language 커스텀 헤더
+ * 3. Accept-Language 헤더 (default 국어)
+ * 만약 지원하지 않는 언어일경우, 지역은 그대로 놔두고, 국가는 통일
+ */
+@Component
+public class CustomLocaleResolver implements LocaleResolver {
+
+    private static final Locale DEFAULT_LOCALE = Locale.KOREA;
+    private final AcceptHeaderLocaleResolver acceptHeaderLocaleResolver = new AcceptHeaderLocaleResolver();
+
+    public CustomLocaleResolver() {
+        acceptHeaderLocaleResolver.setDefaultLocale(DEFAULT_LOCALE);
+    }
+
+    @NotNull
+    @Override
+    public Locale resolveLocale(HttpServletRequest request) {
+
+        String langParam = request.getParameter(CustomQueryParameters.LANGUAGE_PARAMETER);
+        if (hasText(langParam)) {
+            return validateLanguageOrDefault(Locale.forLanguageTag(langParam));
+        }
+        String langHeader = request.getHeader(CustomHeaders.LANGUAGE_HEADER);
+        if (hasText(langHeader)) {
+            return validateLanguageOrDefault(Locale.forLanguageTag(langHeader));
+        }
+
+        return acceptHeaderLocaleResolver.resolveLocale(request);
+    }
+
+    private Locale validateLanguageOrDefault(Locale locale) {
+        for (Language language : Language.values()) {
+            if (language.name().equalsIgnoreCase(locale.getLanguage())) {
+                return locale;
+            }
+        }
+        return new Locale.Builder()
+                .setLanguage(DEFAULT_LOCALE.getLanguage())
+                .setRegion(locale.getCountry())
+                .build();
+    }
+
+
+    @Override
+    public void setLocale(HttpServletRequest request, HttpServletResponse response, Locale locale) {
+        // 저장안할거
+    }
+
+}

--- a/src/main/java/com/happypill/api/config/localeContextResolver/CustomTimeZoneResolver.java
+++ b/src/main/java/com/happypill/api/config/localeContextResolver/CustomTimeZoneResolver.java
@@ -1,0 +1,50 @@
+package com.happypill.api.config.localeContextResolver;
+
+import com.happypill.api.config.CustomHeaders;
+import com.happypill.api.config.CustomQueryParameters;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.TimeZone;
+
+import static org.springframework.util.StringUtils.hasText;
+
+
+/**
+ * HappyPill 애플리케이션용 커스텀 TimeZoneResolver
+ * <p>
+ * 우선순위:
+ * 1. ?timeZone 쿼리파라미터
+ * 2. APP-TIME-ZONE 커스텀 헤더
+ * 3. 한국시간
+ */
+@Component
+public class CustomTimeZoneResolver {
+
+    private static final TimeZone DEFAULT_TIMEZONE = TimeZone.getDefault();
+
+    public TimeZone resolveTimeZone(HttpServletRequest request) {
+
+        String timeZoneId;
+
+        timeZoneId = request.getParameter(CustomQueryParameters.TIMEZONE_PARAMETER);
+        if (hasText(timeZoneId)) {
+            return validateTimeZoneOrDefault(timeZoneId);
+        }
+
+        timeZoneId = request.getHeader(CustomHeaders.TIMEZONE_HEADER);
+        if (hasText(timeZoneId)) {
+            return validateTimeZoneOrDefault(timeZoneId);
+        }
+        return DEFAULT_TIMEZONE;
+    }
+
+    private TimeZone validateTimeZoneOrDefault(String timeZone) {
+        for (var t : TimeZone.getAvailableIDs()) {
+            if (t.equalsIgnoreCase(timeZone)) {
+                return TimeZone.getTimeZone(t);
+            }
+        }
+        return DEFAULT_TIMEZONE;
+    }
+}

--- a/src/main/java/com/happypill/api/config/localeContextResolver/HappypillLocaleContextResolver.java
+++ b/src/main/java/com/happypill/api/config/localeContextResolver/HappypillLocaleContextResolver.java
@@ -1,0 +1,32 @@
+package com.happypill.api.config.localeContextResolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.i18n.LocaleContext;
+import org.springframework.context.i18n.SimpleTimeZoneAwareLocaleContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.LocaleContextResolver;
+
+import java.util.Locale;
+import java.util.TimeZone;
+
+@Component("localeResolver")
+@RequiredArgsConstructor
+public class HappypillLocaleContextResolver implements LocaleContextResolver {
+
+    private final CustomLocaleResolver localeResolver;
+    private final CustomTimeZoneResolver timeZoneResolver;
+
+    @Override
+    public LocaleContext resolveLocaleContext(HttpServletRequest request) {
+        Locale locale = localeResolver.resolveLocale(request);
+        TimeZone timeZone = timeZoneResolver.resolveTimeZone(request);
+        return new SimpleTimeZoneAwareLocaleContext(locale, timeZone);
+    }
+
+    @Override
+    public void setLocaleContext(HttpServletRequest request, HttpServletResponse response, LocaleContext localeContext) {
+        throw new AssertionError("unreachable");
+    }
+}

--- a/src/main/java/com/happypill/application/entity/enums/Language.java
+++ b/src/main/java/com/happypill/application/entity/enums/Language.java
@@ -1,24 +1,22 @@
 package com.happypill.application.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Language {
     KO("Korean"),
     EN("English");
 
     private final String description;
 
-    Language(String description) {
-        this.description = description;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
     public static Language parseLanguage(String language) {
-        try {
-            return Language.valueOf(language.toUpperCase());
-        } catch (Exception e) {
-            return Language.KO;
+        for (var l : Language.values()) {
+            if (l.name().equalsIgnoreCase(language)) {
+                return l;
+            }
         }
+        return KO;
     }
 }

--- a/src/test/java/com/happypill/api/config/localeContextResolver/CustomLocaleResolverTest.java
+++ b/src/test/java/com/happypill/api/config/localeContextResolver/CustomLocaleResolverTest.java
@@ -1,0 +1,205 @@
+package com.happypill.api.config.localeContextResolver;
+
+import com.happypill.api.config.CustomHeaders;
+import com.happypill.api.config.CustomQueryParameters;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("CustomLocaleResolver 테스트")
+class CustomLocaleResolverTest {
+
+    private final CustomLocaleResolver resolver = new CustomLocaleResolver();
+
+    @Test
+    @DisplayName("쿼리 파라미터가 최우선으로 적용되어야 한다")
+    void queryParameterShouldHaveHighestPriority() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "en");
+        request.addHeader(CustomHeaders.LANGUAGE_HEADER, "ko");
+        request.addHeader("Accept-Language", "ja-JP");
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertThat(result.getLanguage()).isEqualTo("en");
+    }
+
+    @Test
+    @DisplayName("헤더가 두 번째 우선순위를 가져야 한다")
+    void headerShouldHaveSecondPriority() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(CustomHeaders.LANGUAGE_HEADER, "en");
+        request.addHeader("Accept-Language", "ko-KR");
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertThat(result.getLanguage()).isEqualTo("en");
+    }
+
+    @Test
+    @DisplayName("Accept-Language 헤더가 마지막 우선순위를 가져야 한다")
+    void acceptLanguageHeaderShouldHaveLowestPriority() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept-Language", "en-US,en;q=0.9");
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertThat(result.getLanguage()).isEqualTo("en");
+    }
+
+    @Test
+    @DisplayName("지원하는 언어(KO, EN)는 정상 처리되어야 한다")
+    void supportedLanguagesShouldBeProcessedCorrectly() {
+        // given
+        MockHttpServletRequest koRequest = new MockHttpServletRequest();
+        koRequest.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "ko");
+
+        MockHttpServletRequest enRequest = new MockHttpServletRequest();
+        enRequest.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "en");
+
+        // when
+        Locale koResult = resolver.resolveLocale(koRequest);
+        Locale enResult = resolver.resolveLocale(enRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(koResult.getLanguage()).isEqualTo("ko"),
+                () -> assertThat(enResult.getLanguage()).isEqualTo("en")
+        );
+    }
+
+    @Test
+    @DisplayName("대소문자 무관하게 처리되어야 한다")
+    void shouldBeCaseInsensitive() {
+        // given
+        MockHttpServletRequest upperRequest = new MockHttpServletRequest();
+        upperRequest.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "EN");
+
+        MockHttpServletRequest mixedRequest = new MockHttpServletRequest();
+        mixedRequest.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "Ko");
+
+        // when
+        Locale upperResult = resolver.resolveLocale(upperRequest);
+        Locale mixedResult = resolver.resolveLocale(mixedRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(upperResult.getLanguage()).isEqualTo("en"),
+                () -> assertThat(mixedResult.getLanguage()).isEqualTo("ko")
+        );
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 언어는 기본값(ko)으로 처리되고 지역은 유지되어야 한다")
+    void unsupportedLanguageShouldFallbackToDefaultWithRegionPreserved() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "fr-FR");
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getLanguage()).isEqualTo("ko"),
+                () -> assertThat(result.getCountry()).isEqualTo("FR")
+        );
+    }
+
+    @Test
+    @DisplayName("지역 코드가 없는 지원하지 않는 언어는 기본값(ko)으로 처리되어야 한다")
+    void unsupportedLanguageWithoutRegionShouldFallbackToDefault() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "fr");
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertAll(
+                () -> assertThat(result.getLanguage()).isEqualTo("ko"),
+                () -> assertThat(result.getCountry()).isEmpty()
+        );
+    }
+
+    @Test
+    @DisplayName("아무 파라미터도 없으면 기본값(ko)이 적용되어야 한다")
+    void shouldUseDefaultWhenNoParameters() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertThat(result.getLanguage()).isEqualTo("ko");
+    }
+
+    @Test
+    @DisplayName("빈 값이나 null 값은 무시되고 다음 우선순위가 적용되어야 한다")
+    void emptyOrNullValuesShouldBeIgnored() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "  ");
+        request.addHeader(CustomHeaders.LANGUAGE_HEADER, "en");
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertThat(result.getLanguage()).isEqualTo("en");
+    }
+
+    @Test
+    @DisplayName("복합 언어-지역 태그가 정상 처리되어야 한다")
+    void complexLanguageTagsShouldBeProcessedCorrectly() {
+        // given
+        MockHttpServletRequest enUsRequest = new MockHttpServletRequest();
+        enUsRequest.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "en-US");
+
+        MockHttpServletRequest koKrRequest = new MockHttpServletRequest();
+        koKrRequest.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "ko-KR");
+
+        // when
+        Locale enUsResult = resolver.resolveLocale(enUsRequest);
+        Locale koKrResult = resolver.resolveLocale(koKrRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(enUsResult.getLanguage()).isEqualTo("en"),
+                () -> assertThat(enUsResult.getCountry()).isEqualTo("US"),
+                () -> assertThat(koKrResult.getLanguage()).isEqualTo("ko"),
+                () -> assertThat(koKrResult.getCountry()).isEqualTo("KR")
+        );
+    }
+
+    @Test
+    @DisplayName("Accept-Language 헤더의 복잡한 형태도 정상 처리되어야 한다")
+    void complexAcceptLanguageHeaderShouldBeProcessedCorrectly() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7");
+
+        // when
+        Locale result = resolver.resolveLocale(request);
+
+        // then
+        assertThat(result.getLanguage()).isEqualTo("ko");
+    }
+
+}

--- a/src/test/java/com/happypill/api/config/localeContextResolver/CustomTimeZoneResolverTest.java
+++ b/src/test/java/com/happypill/api/config/localeContextResolver/CustomTimeZoneResolverTest.java
@@ -1,0 +1,220 @@
+package com.happypill.api.config.localeContextResolver;
+
+import com.happypill.api.config.CustomHeaders;
+import com.happypill.api.config.CustomQueryParameters;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("CustomTimeZoneResolver 테스트")
+class CustomTimeZoneResolverTest {
+
+    private final CustomTimeZoneResolver resolver = new CustomTimeZoneResolver();
+
+    @Test
+    @DisplayName("쿼리 파라미터가 최우선으로 적용되어야 한다")
+    void queryParameterShouldHaveHighestPriority() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "America/New_York");
+        request.addHeader(CustomHeaders.TIMEZONE_HEADER, "Asia/Tokyo");
+
+        // when
+        TimeZone result = resolver.resolveTimeZone(request);
+
+        // then
+        assertThat(result.getID()).isEqualTo("America/New_York");
+    }
+
+    @Test
+    @DisplayName("헤더가 두 번째 우선순위를 가져야 한다")
+    void headerShouldHaveSecondPriority() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(CustomHeaders.TIMEZONE_HEADER, "Europe/London");
+
+        // when
+        TimeZone result = resolver.resolveTimeZone(request);
+
+        // then
+        assertThat(result.getID()).isEqualTo("Europe/London");
+    }
+
+    @Test
+    @DisplayName("유효한 타임존들이 정상 처리되어야 한다")
+    void validTimeZonesShouldBeProcessedCorrectly() {
+        // given
+        MockHttpServletRequest asiaSeoulRequest = new MockHttpServletRequest();
+        asiaSeoulRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "Asia/Seoul");
+
+        MockHttpServletRequest americaNewYorkRequest = new MockHttpServletRequest();
+        americaNewYorkRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "America/New_York");
+
+        MockHttpServletRequest europeLondonRequest = new MockHttpServletRequest();
+        europeLondonRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "Europe/London");
+
+        MockHttpServletRequest utcRequest = new MockHttpServletRequest();
+        utcRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "UTC");
+
+        // when
+        TimeZone asiaSeoulResult = resolver.resolveTimeZone(asiaSeoulRequest);
+        TimeZone americaNewYorkResult = resolver.resolveTimeZone(americaNewYorkRequest);
+        TimeZone europeLondonResult = resolver.resolveTimeZone(europeLondonRequest);
+        TimeZone utcResult = resolver.resolveTimeZone(utcRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(asiaSeoulResult.getID()).isEqualTo("Asia/Seoul"),
+                () -> assertThat(americaNewYorkResult.getID()).isEqualTo("America/New_York"),
+                () -> assertThat(europeLondonResult.getID()).isEqualTo("Europe/London"),
+                () -> assertThat(utcResult.getID()).isEqualTo("UTC")
+        );
+    }
+
+    @Test
+    @DisplayName("대소문자 무관하게 처리되어야 한다")
+    void shouldBeCaseInsensitive() {
+        // given
+        MockHttpServletRequest lowerCaseRequest = new MockHttpServletRequest();
+        lowerCaseRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "asia/seoul");
+
+        MockHttpServletRequest upperCaseRequest = new MockHttpServletRequest();
+        upperCaseRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "AMERICA/NEW_YORK");
+
+        MockHttpServletRequest mixedCaseRequest = new MockHttpServletRequest();
+        mixedCaseRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "Europe/LONDON");
+
+        // when
+        TimeZone lowerCaseResult = resolver.resolveTimeZone(lowerCaseRequest);
+        TimeZone upperCaseResult = resolver.resolveTimeZone(upperCaseRequest);
+        TimeZone mixedCaseResult = resolver.resolveTimeZone(mixedCaseRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(lowerCaseResult.getID()).isEqualTo("Asia/Seoul"),
+                () -> assertThat(upperCaseResult.getID()).isEqualTo("America/New_York"),
+                () -> assertThat(mixedCaseResult.getID()).isEqualTo("Europe/London")
+        );
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 타임존은 시스템 기본값으로 처리되어야 한다")
+    void invalidTimeZoneShouldFallbackToDefault() {
+        // given
+        MockHttpServletRequest invalidRequest = new MockHttpServletRequest();
+        invalidRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "Invalid/TimeZone");
+
+        MockHttpServletRequest nonExistentRequest = new MockHttpServletRequest();
+        nonExistentRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "NotExist/Zone");
+
+        // when
+        TimeZone invalidResult = resolver.resolveTimeZone(invalidRequest);
+        TimeZone nonExistentResult = resolver.resolveTimeZone(nonExistentRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(invalidResult).isEqualTo(TimeZone.getDefault()),
+                () -> assertThat(nonExistentResult).isEqualTo(TimeZone.getDefault())
+        );
+    }
+
+    @Test
+    @DisplayName("아무 파라미터도 없으면 시스템 기본값이 적용되어야 한다")
+    void shouldUseDefaultWhenNoParameters() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        TimeZone result = resolver.resolveTimeZone(request);
+
+        // then
+        assertThat(result).isEqualTo(TimeZone.getDefault());
+    }
+
+    @Test
+    @DisplayName("빈 값이나 null 값은 무시되고 다음 우선순위가 적용되어야 한다")
+    void emptyOrNullValuesShouldBeIgnored() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "");
+        request.addHeader(CustomHeaders.TIMEZONE_HEADER, "Europe/Paris");
+
+        // when
+        TimeZone result = resolver.resolveTimeZone(request);
+
+        // then
+        assertThat(result.getID()).isEqualTo("Europe/Paris");
+    }
+
+    @Test
+    @DisplayName("whitespace만 있는 값은 무시되고 다음 우선순위가 적용되어야 한다")
+    void whitespaceOnlyValuesShouldBeIgnored() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "   ");
+        request.addHeader(CustomHeaders.TIMEZONE_HEADER, "Asia/Tokyo");
+
+        // when
+        TimeZone result = resolver.resolveTimeZone(request);
+
+        // then
+        assertThat(result.getID()).isEqualTo("Asia/Tokyo");
+    }
+
+
+    @Test
+    @DisplayName("쿼리 파라미터와 헤더에 서로 다른 값이 있을 때 쿼리 파라미터가 우선되어야 한다")
+    void queryParameterShouldOverrideHeader() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "America/Los_Angeles");
+        request.addHeader(CustomHeaders.TIMEZONE_HEADER, "Asia/Shanghai");
+
+        // when
+        TimeZone result = resolver.resolveTimeZone(request);
+
+        // then
+        assertThat(result.getID()).isEqualTo("America/Los_Angeles");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 쿼리 파라미터가 있을 때 헤더 값이 사용되지 않고 기본값이 적용되어야 한다")
+    void invalidQueryParameterShouldNotFallbackToHeader() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "Invalid/Zone");
+        request.addHeader(CustomHeaders.TIMEZONE_HEADER, "Asia/Seoul");
+
+        // when
+        TimeZone result = resolver.resolveTimeZone(request);
+
+        // then
+        assertThat(result).isEqualTo(TimeZone.getDefault());
+    }
+
+    @Test
+    @DisplayName("StringUtils.isNoneEmpty 메서드가 올바르게 동작하는지 확인")
+    void stringUtilsIsNoneEmptyBehavior() {
+        // given
+        MockHttpServletRequest nullRequest = new MockHttpServletRequest();
+        // parameter를 설정하지 않으면 null 반환
+
+        MockHttpServletRequest emptyRequest = new MockHttpServletRequest();
+        emptyRequest.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "");
+
+        // when
+        TimeZone nullResult = resolver.resolveTimeZone(nullRequest);
+        TimeZone emptyResult = resolver.resolveTimeZone(emptyRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(nullResult).isEqualTo(TimeZone.getDefault()),
+                () -> assertThat(emptyResult).isEqualTo(TimeZone.getDefault())
+        );
+    }
+}

--- a/src/test/java/com/happypill/api/config/localeContextResolver/HappypillLocaleContextResolverTest.java
+++ b/src/test/java/com/happypill/api/config/localeContextResolver/HappypillLocaleContextResolverTest.java
@@ -1,0 +1,33 @@
+package com.happypill.api.config.localeContextResolver;
+
+import com.happypill.api.config.CustomQueryParameters;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContext;
+import org.springframework.context.i18n.TimeZoneAwareLocaleContext;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("HappypillLocaleContextResolver 테스트")
+class HappypillLocaleContextResolverTest {
+
+    private final HappypillLocaleContextResolver resolver =
+            new HappypillLocaleContextResolver(new CustomLocaleResolver(), new CustomTimeZoneResolver());
+
+    @Test
+    @DisplayName("LocaleContext를 정상적으로 생성해야 한다")
+    void shouldCreateLocaleContextCorrectly() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(CustomQueryParameters.LANGUAGE_PARAMETER, "en");
+        request.setParameter(CustomQueryParameters.TIMEZONE_PARAMETER, "America/New_York");
+
+        // when
+        LocaleContext context = resolver.resolveLocaleContext(request);
+
+        // then
+        assertThat(context.getLocale().getLanguage()).isEqualTo("en");
+        assertThat(((TimeZoneAwareLocaleContext) context).getTimeZone().getID()).isEqualTo("America/New_York");
+    }
+}


### PR DESCRIPTION


# 티켓
HP-79

# 설명
리펙토링하기엔 코드가 너무 많아져서
LocaleContextResolver 등록/테스트까지만 진행

각각 Locale, timeZone 정보 받게 등록
CustomHeaders 스태틱 클래스에서 헤더정보 받게 변경
언어정보에 따라 Content-language 헤더 응답하게 변경

## 타입
- [ ] 버그
- [ ] 작업
- [ ] 기능 향상

# 테스트 방법
코드와 관련하여 어떻게 테스트하였는지 작성해주세요

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다