### PR TITLE
HP-105 : [관리자] 카테고리 삭제 endpoint

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
@@ -67,4 +67,10 @@ public class AdminCategoryController {
                                                     @Valid @RequestBody AdminCategoryUpdateRequest request) {
         return adminCategoryService.updateCategory(categoryId, request);
     }
+
+    @DeleteMapping("/{categoryId}")
+    //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
+    public void deleteCategory(@PathVariable Long categoryId){
+        adminCategoryService.deleteCategory(categoryId);
+    }
 }

--- a/src/main/java/com/happypill/application/entity/Product.java
+++ b/src/main/java/com/happypill/application/entity/Product.java
@@ -34,7 +34,7 @@ public class Product extends BaseEntity<Long> {
     private boolean isDeleted;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
+    @JoinColumn(name = "category_id")
     private Category category;
 
     @Version
@@ -69,5 +69,9 @@ public class Product extends BaseEntity<Long> {
     public void deleteProduct(){
         this.isDeleted = true;
         this.isAvailable = false;
+    }
+
+    public void removeCategory(){
+        this.category = null;
     }
 }

--- a/src/main/java/com/happypill/application/repository/product/ProductRepository.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepository.java
@@ -1,5 +1,6 @@
 package com.happypill.application.repository.product;
 
+import com.happypill.application.entity.Category;
 import com.happypill.application.entity.Product;
 import com.happypill.application.entity.ProductInfo;
 import com.happypill.application.entity.enums.Language;
@@ -77,4 +78,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             WHERE p.id IN :productIds
             """)
     List<Product> findAllByIdIn(@Param("productIds") List<Long> productIds);
+
+    List<Product> findAllByCategory(Category category);
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
@@ -2,12 +2,14 @@ package com.happypill.application.service.admin;
 
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
+import com.happypill.application.entity.Product;
 import com.happypill.application.entity.enums.Language;
 import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.pagination.CustomPage;
 import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
+import com.happypill.application.repository.product.ProductRepository;
 import com.happypill.application.service.admin.request.AdminCategoryInfoRequest;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
 import com.happypill.application.service.admin.request.AdminCategoryUpdateRequest;
@@ -32,6 +34,7 @@ public class AdminCategoryService {
 
     private final CategoryRepository categoryRepository;
     private final CategoryInfoRepository categoryInfoRepository;
+    private final ProductRepository productRepository;
 
     @Transactional(readOnly = true)
     //모든 카테고리 조회
@@ -123,5 +126,18 @@ public class AdminCategoryService {
             }
         }
         return AdminCategoryInfoResponse.fromCategoryAndInfos(category, categoryInfoRepository.findAllByCategory(category));
+    }
+
+    public void deleteCategory(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new BusinessException(ExceptionCode.CATEGORY_NOT_FOUND));
+
+        List<CategoryInfo> categoryInfos = categoryInfoRepository.getAllCategoryInfosById(categoryId);
+
+        List<Product> products = productRepository.findAllByCategory(category);
+        products.forEach(Product::removeCategory);
+
+        categoryInfoRepository.deleteAll(categoryInfos);
+        categoryRepository.delete(category);
     }
 }

--- a/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
@@ -2,12 +2,14 @@ package com.happypill.application.service.admin;
 
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
+import com.happypill.application.entity.Product;
 import com.happypill.application.entity.enums.Language;
 import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.pagination.CustomPage;
 import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
+import com.happypill.application.repository.product.ProductRepository;
 import com.happypill.application.service.admin.request.AdminCategoryInfoRequest;
 import com.happypill.application.service.admin.request.AdminCategoryRequest;
 import com.happypill.application.service.admin.request.AdminCategoryUpdateRequest;
@@ -42,6 +44,9 @@ class AdminCategoryServiceTest {
 
     @Autowired
     private CategoryInfoRepository categoryInfoRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
 
     @Test
     @DisplayName("[모든 카테고리 조회] 요청한 locale 에 따라 AdminCategoryListResponse 를 페이지네이션하여 반환한다.")
@@ -236,5 +241,72 @@ class AdminCategoryServiceTest {
 
         // then
         assertThat(categoryInfos).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("[카테고리 삭제] 경로변수의 CategoryId 가 존재하지 않는 값일 때 예외를 반환한다.")
+    void deleteCategory_1(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        List<CategoryInfo> categoryInfoList = List.of(
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+        );
+
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryInfoList);
+
+        //when //then
+        assertThatThrownBy(() -> adminCategoryService.deleteCategory(0L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.CATEGORY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("[카테고리 삭제] 카테고리가 삭제될 때 그 카테고리와 관련된 상품들의 category 필드는 null 값으로 변경된다.")
+    void deleteCategory_2(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        List<CategoryInfo> categoryInfoList = List.of(
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+        );
+        Product product = Product.of(SnowflakeUtil.nextId(), 3500, 5, "https://xxxxx.com/xxxxx", category);
+
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryInfoList);
+        productRepository.save(product);
+
+        //when
+        adminCategoryService.deleteCategory(category.getId());
+
+        //then
+        assertThat(product.getCategory()).isNull();
+    }
+
+    @Test
+    @DisplayName("[카테고리 삭제] 카테고리가 삭제될 때 그 카테고리와 관련된 CategoryInfo 객체들은 모두 DB 내에서 삭제된다.")
+    void deleteCategory_3(){
+        //given
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        List<CategoryInfo> categoryInfoList = List.of(
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+        );
+
+        categoryRepository.save(category);
+        categoryInfoRepository.saveAll(categoryInfoList);
+
+        //when
+        adminCategoryService.deleteCategory(category.getId());
+
+        //then
+        for(CategoryInfo ci : categoryInfoList){
+            boolean categoryInfoExists = categoryInfoRepository.existsById(ci.getId());
+            assertThat(categoryInfoExists).isFalse();
+        }
+
+        boolean categoryExists = categoryRepository.existsById(category.getId());
+        assertThat(categoryExists).isFalse();
     }
 }


### PR DESCRIPTION
# 티켓
HP-105

# 설명
1. 카테고리 삭제 endpoint 생성
2. Product 엔티티의 category 필드 nullable = true 로 변경
3. Product 엔티티에 removeCategory 메서드 추가

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합 테스트 및 postman 으로 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다