### PR TITLE
HP-119 : [관리자] 모든 구독 상품 조회

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
@@ -3,6 +3,7 @@ package com.happypill.api.controller.admin;
 import com.happypill.application.pagination.CustomPage;
 import com.happypill.application.service.admin.AdminUserService;
 import com.happypill.application.service.admin.request.AdminUserUpdateRequest;
+import com.happypill.application.service.admin.response.AdminSubscriptionListResponse;
 import com.happypill.application.service.admin.response.AdminUserDetailResponse;
 import com.happypill.application.service.admin.response.AdminUserListResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Locale;
 
 @Tag(name = "[관리자] 회원", description = "관리자가 사용자 정보를 조회/관리하기 위한 API")
 @RestController
@@ -42,5 +45,15 @@ public class AdminUserController {
     public AdminUserDetailResponse updateUser(@PathVariable Long userId,
                                               @Valid @RequestBody AdminUserUpdateRequest request) {
         return adminUserService.updateUserProfile(userId, request);
+    }
+
+    //모든 구독 상품 조회
+    @GetMapping("/subscriptions")
+    //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
+    public CustomPage<AdminSubscriptionListResponse> getSubscriptions(@RequestParam(value = "page", defaultValue = "1") int page,
+                                                                      @RequestParam(value = "size", defaultValue = "8") int size,
+                                                                      Locale locale){
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return adminUserService.getAllSubscriptions(pageable, locale);
     }
 }

--- a/src/main/java/com/happypill/application/entity/Subscription.java
+++ b/src/main/java/com/happypill/application/entity/Subscription.java
@@ -1,17 +1,20 @@
 package com.happypill.application.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PRIVATE)
 @Table(name = "subscriptions")
 public class Subscription extends BaseEntity<Long> {
 
@@ -20,6 +23,9 @@ public class Subscription extends BaseEntity<Long> {
 
     @Column(name = "expired_date", columnDefinition = "TIMESTAMPTZ", nullable = false)
     private ZonedDateTime expiredDate;
+
+    @Column(name = "next_delivery_date", columnDefinition = "TIMESTAMPTZ")
+    private ZonedDateTime nextDeliveryDate;
 
     @Column(nullable = false)
     private boolean isCompleted;
@@ -31,4 +37,13 @@ public class Subscription extends BaseEntity<Long> {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private HappypillUser user;
+
+    public static Subscription of(Long id,
+                                  ZonedDateTime expiredDate,
+                                  ZonedDateTime nextDeliveryDate,
+                                  boolean isCompleted,
+                                  OrderLine orderLine,
+                                  HappypillUser user){
+        return new Subscription(id, expiredDate, nextDeliveryDate, isCompleted, orderLine, user);
+    }
 }

--- a/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepository.java
@@ -3,5 +3,5 @@ package com.happypill.application.repository.subscription;
 import com.happypill.application.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long>, SubscriptionRepositoryCustom {
 }

--- a/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryCustom.java
+++ b/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.happypill.application.repository.subscription;
+
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.entity.enums.OrderStatus;
+import com.happypill.application.service.admin.response.AdminSubscriptionListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SubscriptionRepositoryCustom {
+    Page<AdminSubscriptionListResponse> findSubscriptionsByLanguageAndCompletionAndStatus(
+            Language language, boolean isCompleted, OrderStatus orderStatus, Pageable pageable
+    );
+}

--- a/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.happypill.application.repository.subscription;
+
+import com.happypill.application.entity.*;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.entity.enums.OrderStatus;
+import com.happypill.application.service.admin.response.AdminSubscriptionListResponse;
+import com.happypill.application.service.admin.response.QAdminSubscriptionListResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriptionRepositoryImpl implements SubscriptionRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    @Override
+    public Page<AdminSubscriptionListResponse> findSubscriptionsByLanguageAndCompletionAndStatus(Language language, boolean isCompleted, OrderStatus orderStatus, Pageable pageable) {
+        QSubscription s = QSubscription.subscription;
+        QOrderLine ol = QOrderLine.orderLine;
+        QHappypillUser u = QHappypillUser.happypillUser;
+        QOrder o = QOrder.order;
+        QProduct p = QProduct.product;
+        QProductInfo pi = QProductInfo.productInfo;
+
+        //모든 구독 상품 조회 쿼리
+        List<AdminSubscriptionListResponse> content = jpaQueryFactory
+                .select(new QAdminSubscriptionListResponse(
+                        pi.name,
+                        u.notifyEmail,
+                        s.id.stringValue(),
+                        s.nextDeliveryDate
+                ))
+                .from(s)
+                .join(s.orderLine, ol)
+                .join(s.user, u)
+                .join(ol.order, o)
+                .join(ol.product, p)
+                .join(pi).on(pi.product.eq(p).and(pi.language.eq(language)))
+                .where(
+                        s.isCompleted.eq(isCompleted),
+                        o.status.eq(orderStatus)
+                )
+                .orderBy(s.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 카운트 쿼리 (페이지네이션을 위한 쿼리)
+        Long total = jpaQueryFactory
+                .select(s.count())
+                .from(s)
+                .join(s.orderLine, ol)
+                .join(ol.order, o)
+                .where(
+                        s.isCompleted.eq(isCompleted),
+                        o.status.eq(orderStatus)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+}

--- a/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.happypill.application.repository.subscription;
 
-import com.happypill.application.entity.*;
 import com.happypill.application.entity.enums.Language;
 import com.happypill.application.entity.enums.OrderStatus;
 import com.happypill.application.service.admin.response.AdminSubscriptionListResponse;
@@ -14,52 +13,54 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.happypill.application.entity.QHappypillUser.happypillUser;
+import static com.happypill.application.entity.QOrder.order;
+import static com.happypill.application.entity.QOrderLine.orderLine;
+import static com.happypill.application.entity.QProduct.product;
+import static com.happypill.application.entity.QProductInfo.productInfo;
+import static com.happypill.application.entity.QSubscription.subscription;
+
 @Repository
 @RequiredArgsConstructor
 public class SubscriptionRepositoryImpl implements SubscriptionRepositoryCustom{
 
     private final JPAQueryFactory jpaQueryFactory;
+
     @Override
     public Page<AdminSubscriptionListResponse> findSubscriptionsByLanguageAndCompletionAndStatus(Language language, boolean isCompleted, OrderStatus orderStatus, Pageable pageable) {
-        QSubscription s = QSubscription.subscription;
-        QOrderLine ol = QOrderLine.orderLine;
-        QHappypillUser u = QHappypillUser.happypillUser;
-        QOrder o = QOrder.order;
-        QProduct p = QProduct.product;
-        QProductInfo pi = QProductInfo.productInfo;
 
         //모든 구독 상품 조회 쿼리
         List<AdminSubscriptionListResponse> content = jpaQueryFactory
                 .select(new QAdminSubscriptionListResponse(
-                        pi.name,
-                        u.notifyEmail,
-                        s.id.stringValue(),
-                        s.nextDeliveryDate
+                        productInfo.name,
+                        happypillUser.notifyEmail,
+                        subscription.id.stringValue(),
+                        subscription.nextDeliveryDate
                 ))
-                .from(s)
-                .join(s.orderLine, ol)
-                .join(s.user, u)
-                .join(ol.order, o)
-                .join(ol.product, p)
-                .join(pi).on(pi.product.eq(p).and(pi.language.eq(language)))
+                .from(subscription)
+                .join(subscription.orderLine, orderLine)
+                .join(subscription.user, happypillUser)
+                .join(orderLine.order, order)
+                .join(orderLine.product, product)
+                .join(productInfo).on(productInfo.product.eq(product).and(productInfo.language.eq(language)))
                 .where(
-                        s.isCompleted.eq(isCompleted),
-                        o.status.eq(orderStatus)
+                        subscription.isCompleted.eq(isCompleted),
+                        order.status.eq(orderStatus)
                 )
-                .orderBy(s.id.desc())
+                .orderBy(subscription.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         // 전체 카운트 쿼리 (페이지네이션을 위한 쿼리)
         Long total = jpaQueryFactory
-                .select(s.count())
-                .from(s)
-                .join(s.orderLine, ol)
-                .join(ol.order, o)
+                .select(subscription.count())
+                .from(subscription)
+                .join(subscription.orderLine, orderLine)
+                .join(orderLine.order, order)
                 .where(
-                        s.isCompleted.eq(isCompleted),
-                        o.status.eq(orderStatus)
+                        subscription.isCompleted.eq(isCompleted),
+                        order.status.eq(orderStatus)
                 )
                 .fetchOne();
 

--- a/src/main/java/com/happypill/application/service/admin/AdminUserService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminUserService.java
@@ -1,11 +1,15 @@
 package com.happypill.application.service.admin;
 
 import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.entity.enums.OrderStatus;
 import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.pagination.CustomPage;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import com.happypill.application.repository.subscription.SubscriptionRepository;
 import com.happypill.application.service.admin.request.AdminUserUpdateRequest;
+import com.happypill.application.service.admin.response.AdminSubscriptionListResponse;
 import com.happypill.application.service.admin.response.AdminUserDetailResponse;
 import com.happypill.application.service.admin.response.AdminUserListResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +18,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Locale;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AdminUserService {
 
     private final HappypillUserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     //모든 회원 조회
     public CustomPage<AdminUserListResponse> getAllUsers(Pageable pageable) {
@@ -48,6 +55,20 @@ public class AdminUserService {
         updateNotifyEmail(user, request);
 
         return AdminUserDetailResponse.from(user);
+    }
+
+    //모든 구독 상품 조회
+    public CustomPage<AdminSubscriptionListResponse> getAllSubscriptions(Pageable pageable, Locale locale){
+        Language language = Language.parseLanguage(locale.getLanguage());
+
+        Page<AdminSubscriptionListResponse> responses = subscriptionRepository.findSubscriptionsByLanguageAndCompletionAndStatus(
+                language,
+                false,
+                OrderStatus.COMPLETED,
+                pageable
+        );
+
+        return new CustomPage<>(responses);
     }
 
     private void updateNickname(HappypillUser user, AdminUserUpdateRequest request){

--- a/src/main/java/com/happypill/application/service/admin/response/AdminSubscriptionListResponse.java
+++ b/src/main/java/com/happypill/application/service/admin/response/AdminSubscriptionListResponse.java
@@ -1,0 +1,31 @@
+package com.happypill.application.service.admin.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.ZonedDateTime;
+
+@NoArgsConstructor
+@Setter
+@Getter
+public class AdminSubscriptionListResponse {
+    private String productName;
+    private String notifyEmail;
+    private String subscriptionId;
+    private ZonedDateTime nextDeliveryDate;
+
+    @QueryProjection
+    public AdminSubscriptionListResponse(
+            String productName,
+            String notifyEmail,
+            String subscriptionId,
+            ZonedDateTime nextDeliveryDate
+    ) {
+        this.productName = productName;
+        this.notifyEmail = notifyEmail;
+        this.subscriptionId = subscriptionId;
+        this.nextDeliveryDate = nextDeliveryDate;
+    }
+}

--- a/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
@@ -1,13 +1,22 @@
 package com.happypill.application.service.admin;
 
-import com.happypill.application.entity.HappypillUser;
+import com.happypill.application.entity.*;
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.entity.enums.PaymentMethod;
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
 import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.pagination.CustomPage;
+import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import com.happypill.application.repository.order.OrderRepository;
+import com.happypill.application.repository.orderline.OrderLineRepository;
+import com.happypill.application.repository.product.ProductRepository;
+import com.happypill.application.repository.productinfo.ProductInfoRepository;
+import com.happypill.application.repository.subscription.SubscriptionRepository;
 import com.happypill.application.service.admin.request.AdminUserUpdateRequest;
+import com.happypill.application.service.admin.response.AdminSubscriptionListResponse;
 import com.happypill.application.service.admin.response.AdminUserDetailResponse;
 import com.happypill.application.service.admin.response.AdminUserListResponse;
 import com.happypill.application.util.SnowflakeUtil;
@@ -20,7 +29,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,6 +51,24 @@ class AdminUserServiceTest {
 
     @Autowired
     private HappypillUserRepository userRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderLineRepository orderLineRepository;
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductInfoRepository productInfoRepository;
 
     private HappypillUser generateTestUser() {
         String loginEmail = faker.internet().emailAddress();
@@ -158,5 +189,60 @@ class AdminUserServiceTest {
         //then
         assertThat(updatedUser.getNickName()).isEqualTo(UPDATED_NICKNAME);
         assertThat(updatedUser.getNotifyEmail()).isEqualTo(UPDATED_NOTIFY_EMAIL);
+    }
+
+    @Test
+    @DisplayName("[모든 구독 상품 조회] KO 언어로 요청할 경우 상품명이 한글로 출력된다.")
+    void getAllSubscriptions_1() {
+        //given
+        HappypillUser savedUser = generateTestUser();
+        userRepository.save(savedUser);
+
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        categoryRepository.save(category);
+
+        List<Product> products = List.of(
+                Product.of(SnowflakeUtil.nextId(), 3000, 10, true, "https://xxx.com/xxx", false, category),
+                Product.of(SnowflakeUtil.nextId(), 5000, 10, true, "https://xxx.com/xxx", false, category)
+        );
+        productRepository.saveAll(products);
+
+        List<ProductInfo> productInfos = Arrays.asList(
+                ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "제품명1_KO", "수량 상세1_KO", "경고 메시지1_KO", "사용법1_KO", "https://xxx.com/xxx_KO", "설명1_KO", "회사명1_KO", "간략 설명1_KO", products.get(0)),
+                ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "제품명1_EN", "수량 상세1_EN", "경고 메시지1_EN", "사용법1_EN", "https://xxx.com/xxx_EN", "설명1_EN", "회사명1_EN", "간략 설명1_EN", products.get(0)),
+                ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "제품명2_KO", "수량 상세2_KO", "경고 메시지2_KO", "사용법2_KO", "https://xxx.com/xxx_KO", "설명2_KO", "회사명2_KO", "간략 설명2_KO", products.get(1)),
+                ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "제품명2_EN", "수량 상세2_EN", "경고 메시지2_EN", "사용법2_EN", "https://xxx.com/xxx_EN", "설명2_EN", "회사명2_EN", "간략 설명2_EN", products.get(1))
+        );
+        productInfoRepository.saveAll(productInfos);
+
+        OrderRecipientInfo orderRecipientInfo = OrderRecipientInfo.create("홍길동", "010-1234-5678", "test@gmail.com");
+
+        List<OrderLine> orderLines = List.of(
+                OrderLine.create(1L, 3000, LocalDate.now(), 1, products.get(0)),
+                OrderLine.create(2L, 15000, LocalDate.now(), 3, products.get(1))
+        );
+        Order order = Order.create(SnowflakeUtil.nextId(), "00-00000", PaymentMethod.CARD, orderRecipientInfo, savedUser, orderLines);
+        order.complete();
+        orderRepository.save(order);
+        orderLineRepository.saveAll(orderLines);
+
+        List<Subscription> subscriptions = List.of(
+            Subscription.of(SnowflakeUtil.nextId(), ZonedDateTime.now().plusMonths(orderLines.get(0).getMonth()), ZonedDateTime.now().plusMonths(1), false, orderLines.get(0), savedUser),
+            Subscription.of(SnowflakeUtil.nextId(), ZonedDateTime.now().plusMonths(orderLines.get(1).getMonth()), ZonedDateTime.now().plusMonths(1), false, orderLines.get(1), savedUser)
+        );
+        subscriptionRepository.saveAll(subscriptions);
+
+        Pageable pageable = PageRequest.of(0,5);
+        Locale locale = Locale.KOREA;
+
+        //when
+        CustomPage<AdminSubscriptionListResponse> result = adminUserService.getAllSubscriptions(pageable, locale);
+
+        //then
+        assertThat(result.contents())
+                .hasSize(2);
+        assertThat(result.contents())
+                .extracting(AdminSubscriptionListResponse::getSubscriptionId)
+                .contains(String.valueOf(subscriptions.get(0).getId()));
     }
 }


### PR DESCRIPTION
# 티켓
HP-119

# 설명
1. [관리자페이지] 모든 구독 상품 조회 endpoint 생성
2. Subscription 엔티티에 nextDeliveryDate 필드 추가
3. 커스텀 SubscriptionRepository 추가

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합테스트 및 postman 으로 응답데이터 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 관리자가 구독 상품 목록을 페이지네이션과 언어별로 조회할 수 있는 API가 추가되었습니다.
  * 구독 상품 정보에 다음 배송일이 표시됩니다.

* **버그 수정**
  * 구독 상품 목록 조회 시 상품명이 선택한 언어로 정확히 표시됩니다.

* **테스트**
  * 구독 상품 목록 API의 언어별 응답 및 데이터 반환을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->