### PR TITLE
HP-141 : Swagger 어노테이션이 적용되어 있지 않은 컨트롤러에 어노테이션 적용

### DIFF
--- a/src/main/java/com/happypill/api/controller/ProductController.java
+++ b/src/main/java/com/happypill/api/controller/ProductController.java
@@ -34,6 +34,7 @@ public class ProductController {
         return productService.getProduct(productId, locale);
     }
 
+    @Operation(summary = "다른 고객이 함께 본 상품 조회", description = "다른 고객이 함께 본 상품을 조회합니다.")
     @GetMapping("/related")
     public List<ProductRelatedResponse> getRecommendation() {
         return productService.getRecommendation();

--- a/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
@@ -38,6 +38,7 @@ public class AdminCategoryController {
         return adminCategoryService.getAllCategories(pageable, locale);
     }
 
+    @Operation(summary = "카테고리 등록", description = "카테고리를 등록합니다.")
     @PostMapping
 //   ToDo @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> saveCategories(@RequestBody @Valid AdminCategoryRequest adminCategoryCreateRequestList) {
@@ -46,18 +47,21 @@ public class AdminCategoryController {
         return ResponseEntity.created(URI.create("/api/admin/categories")).build();
     }
 
+    @Operation(summary = "특정 카테고리 조회", description = "특정 카테고리에 대한 정보를 조회합니다.")
     @GetMapping("{categoryId}")
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public AdminCategoryInfoResponse getCategoryDetail(@PathVariable Long categoryId){
         return adminCategoryService.getCategoryDetails(categoryId);
     }
 
+    @Operation(summary = "카테고리 목록 조회", description = "드롭다운에 출력할 카테고리를 조회합니다.")
     @GetMapping("/names")
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public List<CategoryNamesResponse> getCategoryNames(){
         return adminCategoryService.getCategoryNames();
     }
 
+    @Operation(summary = "카테고리 수정", description = "카테고리 정보를 수정합니다.")
     @PatchMapping("/{categoryId}")
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public AdminCategoryInfoResponse updateCategory(@PathVariable Long categoryId,
@@ -65,6 +69,7 @@ public class AdminCategoryController {
         return adminCategoryService.updateCategory(categoryId, request);
     }
 
+    @Operation(summary = "카테고리 삭제", description = "특정 카테고리를 삭제합니다.")
     @DeleteMapping("/{categoryId}")
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public void deleteCategory(@PathVariable Long categoryId){

--- a/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
@@ -40,14 +40,14 @@ public class AdminUserController {
         return adminUserService.getUserDetails(userId);
     }
 
-    //회원 정보 수정
+    @Operation(summary = "회원 정보 수정", description = "회원 정보를 수정하기 위한 API")
     @PatchMapping("/{userId}")
     public AdminUserDetailResponse updateUser(@PathVariable Long userId,
                                               @Valid @RequestBody AdminUserUpdateRequest request) {
         return adminUserService.updateUserProfile(userId, request);
     }
 
-    //모든 구독 상품 조회
+    @Operation(summary = "모든 구독 상품 조회", description = "회원들의 구독 상품을 조회하기 위한 API")
     @GetMapping("/subscriptions")
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public CustomPage<AdminSubscriptionListResponse> getSubscriptions(@RequestParam(value = "page", defaultValue = "1") int page,

--- a/src/main/java/com/happypill/api/controller/order/OrderController.java
+++ b/src/main/java/com/happypill/api/controller/order/OrderController.java
@@ -7,6 +7,9 @@ import com.happypill.application.service.order.request.OrderCreateRequest;
 import com.happypill.application.service.order.request.OrderPaymentCompleteRequest;
 import com.happypill.application.service.order.response.OrderResponse;
 import com.happypill.application.service.order.response.PaymentConfirmResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,18 +17,21 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "주문", description = "사용자의 주문 및 결제 처리를 위한 API")
 @RestController
 @Slf4j
 @RequiredArgsConstructor
 public class OrderController {
     private final OrderService orderService;
 
+    @Operation(summary = "주문 생성", description = "사용자가 상품을 주문하는 API")
     @PostMapping("/api/order")
     public OrderResponse createOrder(@HappypillUser UserContext userContext, @RequestBody @Valid OrderCreateRequest request) {
 
         return orderService.createOrder(userContext, request);
     }
 
+    @Operation(summary = "결제 완료 확인", description = "결제 완료 후 결제 정보를 검증하고 주문 상태를 확정하는 API")
     @PostMapping("/api/order/payment-confirm")
     public PaymentConfirmResponse confirmPayment(@HappypillUser UserContext userContext, @RequestBody @Valid OrderPaymentCompleteRequest request) {
         return orderService.confirmPayment(request);

--- a/src/main/java/com/happypill/api/controller/test/OAuth2TestController.java
+++ b/src/main/java/com/happypill/api/controller/test/OAuth2TestController.java
@@ -1,5 +1,6 @@
 package com.happypill.api.controller.test;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 개발용 임시 redirect
  */
+@Hidden
 @RestController
 public class OAuth2TestController {
 

--- a/src/main/java/com/happypill/api/controller/test/TestController.java
+++ b/src/main/java/com/happypill/api/controller/test/TestController.java
@@ -2,12 +2,14 @@ package com.happypill.api.controller.test;
 
 import com.happypill.api.config.auth.jwt.JwtService;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.lang.management.ManagementFactory;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 public class TestController {

--- a/src/main/java/com/happypill/application/swagger/SwaggerConfig.java
+++ b/src/main/java/com/happypill/application/swagger/SwaggerConfig.java
@@ -76,6 +76,17 @@ public class SwaggerConfig {
     }
 
     @Bean
+    public GroupedOpenApi orderApi(OpenApiCustomizer globalResponseCustomizer,
+                                   OperationCustomizer securityResponseCustomizer) {
+        return GroupedOpenApi.builder()
+                .group("주문 API")
+                .pathsToMatch("/api/order/**")
+                .addOpenApiCustomizer(globalResponseCustomizer)
+                .addOperationCustomizer(securityResponseCustomizer)
+                .build();
+    }
+
+    @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info()


### PR DESCRIPTION
# 티켓
HP-141

# 설명
-  Swagger 어노테이션이 적용되어 있지 않은 컨트롤러에 어노테이션 적용
-  Test 관련 컨트롤러는 Hidden 처리
-  SwaggerConfig 에 order 컨트롤러를 그룹화

## 타입
- [ ] 버그
- [ ] 작업
- [x] 기능 향상

# 테스트 방법
테스트 없음

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [ ] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 관리자 카테고리, 사용자, 주문 관련 API 엔드포인트에 대한 설명이 Swagger(OpenAPI) 문서에 추가되어 API 사용성이 향상되었습니다.
  * 테스트 관련 컨트롤러(OAuth2TestController, TestController)가 Swagger 문서에서 숨김 처리되었습니다.
  * 주문 API 그룹이 Swagger 문서에 별도로 추가되어 주문 관련 엔드포인트를 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->