### PR TITLE
HP-131 : 카테고리 간단설명, 배너이미지 필드 삭제

### DIFF
--- a/src/main/java/com/happypill/application/entity/Category.java
+++ b/src/main/java/com/happypill/application/entity/Category.java
@@ -24,15 +24,11 @@ public class Category extends BaseEntity<Long> {
     @Column(nullable = false)
     private String thumbnailUrl;
 
-    @Column(nullable = false)
-    private String bannerUrl;
-
-    public static Category of(Long categoryId, String thumbnailUrl, String bannerUrl) {
-        return new Category(categoryId, thumbnailUrl, bannerUrl);
+    public static Category of(Long categoryId, String thumbnailUrl) {
+        return new Category(categoryId, thumbnailUrl);
     }
 
-    public void update(String thumbnailUrl, String bannerUrl){
+    public void update(String thumbnailUrl){
         this.thumbnailUrl = thumbnailUrl;
-        this.bannerUrl = bannerUrl;
     }
 }

--- a/src/main/java/com/happypill/application/entity/CategoryInfo.java
+++ b/src/main/java/com/happypill/application/entity/CategoryInfo.java
@@ -28,19 +28,15 @@ public class CategoryInfo extends BaseEntity<Long> {
     @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(nullable = false)
-    private String description;
-
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
-    public static CategoryInfo of(Long categoryInfoId, Language language, String name, String description, Category category) {
-        return new CategoryInfo(categoryInfoId, language, name, description, category);
+    public static CategoryInfo of(Long categoryInfoId, Language language, String name, Category category) {
+        return new CategoryInfo(categoryInfoId, language, name, category);
     }
 
-    public void update(String name, String description){
+    public void update(String name){
         this.name = name;
-        this.description = description;
     }
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
@@ -64,12 +64,12 @@ public class AdminCategoryService {
         List<CategoryInfo> categoryInfos = new ArrayList<>();
         CategoryInfo categoryInfo;
         Language language;
-        Category category = Category.of(SnowflakeUtil.nextId(), adminCategoryCreateRequest.thumbnailUrl(), adminCategoryCreateRequest.bannerImgUrl());
+        Category category = Category.of(SnowflakeUtil.nextId(), adminCategoryCreateRequest.thumbnailUrl());
         categories.add(category);
 
         for (AdminCategoryInfoRequest request : adminCategoryCreateRequest.categoryInfoRequests()) {
             language = Language.parseLanguage(request.language());
-            categoryInfo = CategoryInfo.of(SnowflakeUtil.nextId(), language, request.name(), request.description(), category);
+            categoryInfo = CategoryInfo.of(SnowflakeUtil.nextId(), language, request.name(), category);
 
             categoryInfos.add(categoryInfo);
         }
@@ -108,13 +108,13 @@ public class AdminCategoryService {
         Category category = this.categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.CATEGORY_NOT_FOUND));
 
-        category.update(request.thumbnailUrl(), request.bannerUrl());
+        category.update(request.thumbnailUrl());
 
         List<CategoryInfo> categoryInfoList = categoryInfoRepository.getAllCategoryInfosById(category.getId());
 
         for(CategoryInfoRequest dto : request.categoryInfos()){
             if(dto.categoryInfoId() == null){ //만약 등록되어 있지 않은 CategoryInfo 가 작성되는 경우 객체 생성
-                categoryInfoRepository.save(CategoryInfo.of(SnowflakeUtil.nextId(), dto.language(), dto.name(), dto.description(), category));
+                categoryInfoRepository.save(CategoryInfo.of(SnowflakeUtil.nextId(), dto.language(), dto.name(), category));
             }
             else{
                 CategoryInfo categoryInfo = categoryInfoList.stream()
@@ -122,7 +122,7 @@ public class AdminCategoryService {
                         .findFirst()
                         .orElseThrow(() -> new BusinessException(ExceptionCode.CATEGORY_INFO_NOT_FOUND));
 
-                categoryInfo.update(dto.name(), dto.description());
+                categoryInfo.update(dto.name());
             }
         }
         return AdminCategoryInfoResponse.fromCategoryAndInfos(category, categoryInfoRepository.findAllByCategory(category));

--- a/src/main/java/com/happypill/application/service/admin/request/AdminCategoryInfoRequest.java
+++ b/src/main/java/com/happypill/application/service/admin/request/AdminCategoryInfoRequest.java
@@ -8,9 +8,6 @@ public record AdminCategoryInfoRequest (
         String language,
 
         @NotNull(message = "이름은 필수 입력란입니다")
-        String name,
-
-        @NotNull(message = "설명란은 필수 입력란입니다")
-        String description
+        String name
 ){
 }

--- a/src/main/java/com/happypill/application/service/admin/request/AdminCategoryRequest.java
+++ b/src/main/java/com/happypill/application/service/admin/request/AdminCategoryRequest.java
@@ -8,9 +8,6 @@ import java.util.List;
 
 public record AdminCategoryRequest (
 
-        @NotNull(message = "배너사진은 필수 입력란입니다")
-        String bannerImgUrl,
-
         @NotNull(message = "썸네일사진은 필수 입력란입니다")
         String thumbnailUrl,
 

--- a/src/main/java/com/happypill/application/service/admin/request/AdminCategoryUpdateRequest.java
+++ b/src/main/java/com/happypill/application/service/admin/request/AdminCategoryUpdateRequest.java
@@ -12,9 +12,6 @@ public record AdminCategoryUpdateRequest(
         @NotNull(message = "썸네일사진은 필수 입력란입니다")
         String thumbnailUrl,
 
-        @NotNull(message = "배너사진은 필수 입력란입니다")
-        String bannerUrl,
-
         @Size(min = 1, message = "카테고리 정보는 필수 입력란입니다")
         List<@Valid CategoryInfoRequest> categoryInfos
 ) {

--- a/src/main/java/com/happypill/application/service/admin/response/AdminCategoryInfoResponse.java
+++ b/src/main/java/com/happypill/application/service/admin/response/AdminCategoryInfoResponse.java
@@ -9,7 +9,6 @@ import java.util.List;
 public record AdminCategoryInfoResponse(
         String categoryId,
         String thumbnailUrl,
-        String bannerUrl,
         List<CategoryInfoResponse> categoryInfo
 ) {
     public static AdminCategoryInfoResponse fromCategoryAndInfos(Category category, List<CategoryInfo> categoryInfos){
@@ -20,7 +19,6 @@ public record AdminCategoryInfoResponse(
         return new AdminCategoryInfoResponse(
                 category.getId().toString(),
                 category.getThumbnailUrl(),
-                category.getBannerUrl(),
                 categoryInfoList
         );
     }

--- a/src/main/java/com/happypill/application/service/admin/response/AdminCategoryListResponse.java
+++ b/src/main/java/com/happypill/application/service/admin/response/AdminCategoryListResponse.java
@@ -6,17 +6,13 @@ import com.happypill.application.entity.CategoryInfo;
 public record AdminCategoryListResponse(
         String categoryId,
         String name,
-        String description,
-        String thumbnailUrl,
-        String bannerImgUrl
+        String thumbnailUrl
 ) {
     public static AdminCategoryListResponse from(CategoryInfo categoryInfo, Category category){
         return new AdminCategoryListResponse(
                 category.getId().toString(),
                 categoryInfo.getName(),
-                categoryInfo.getDescription(),
-                category.getThumbnailUrl(),
-                category.getBannerUrl()
+                category.getThumbnailUrl()
         );
     }
 }

--- a/src/main/java/com/happypill/application/service/category/CategoryService.java
+++ b/src/main/java/com/happypill/application/service/category/CategoryService.java
@@ -29,7 +29,7 @@ public class CategoryService {
         for (CategoryInfo categoryInfo : categoryInfoList) {
             category = categoryInfo.getCategory();
             response = new CategoryResponse(category.getId().toString(), category.getThumbnailUrl(),
-                    categoryInfo.getName(), categoryInfo.getDescription(), category.getBannerUrl());
+                    categoryInfo.getName());
             results.add(response);
         }
 

--- a/src/main/java/com/happypill/application/service/category/dto/response/CategoryInfoResponse.java
+++ b/src/main/java/com/happypill/application/service/category/dto/response/CategoryInfoResponse.java
@@ -6,15 +6,13 @@ import com.happypill.application.entity.enums.Language;
 public record CategoryInfoResponse(
         String categoryInfoId,
         Language language,
-        String name,
-        String description
+        String name
 ) {
     public static CategoryInfoResponse fromEntity(CategoryInfo categoryInfo){
         return new CategoryInfoResponse(
                 categoryInfo.getId().toString(),
                 categoryInfo.getLanguage(),
-                categoryInfo.getName(),
-                categoryInfo.getDescription()
+                categoryInfo.getName()
         );
     }
 }

--- a/src/main/java/com/happypill/application/service/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/happypill/application/service/category/dto/response/CategoryResponse.java
@@ -3,8 +3,6 @@ package com.happypill.application.service.category.dto.response;
 public record CategoryResponse (
      String categoryId,
      String thumbnailUrl,
-     String name,
-     String description,
-     String bannerImgUrl
+     String name
 ) {
 }

--- a/src/main/java/com/happypill/application/service/category/request/CategoryInfoRequest.java
+++ b/src/main/java/com/happypill/application/service/category/request/CategoryInfoRequest.java
@@ -12,9 +12,6 @@ public record CategoryInfoRequest(
         Language language,
 
         @NotEmpty(message = "이름은 필수 입력란입니다")
-        String name,
-
-        @NotEmpty(message = "설명란은 필수 입력란입니다")
-        String description
+        String name
 ) {
 }

--- a/src/main/java/com/happypill/application/util/DataInitialiser.java
+++ b/src/main/java/com/happypill/application/util/DataInitialiser.java
@@ -39,28 +39,21 @@ public class DataInitialiser implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) throws Exception {
         List<Category> categoryList = Arrays.asList(
-                Category.of(SnowflakeUtil.nextId(), "www.vitamin_thumbnail.com", "www.vitamin_banner.com"),
-                Category.of(SnowflakeUtil.nextId(), "www.mineral_thumbnail.com", "www.mineral_banner.com"),
-                Category.of(SnowflakeUtil.nextId(), "www.herb_thumbnail.com", "www.herb_banner.com"),
-                Category.of(SnowflakeUtil.nextId(), "www.probiotics_thumbnail.com", "www.probiotics_banner.com")
+                Category.of(SnowflakeUtil.nextId(), "www.vitamin_thumbnail.com"),
+                Category.of(SnowflakeUtil.nextId(), "www.mineral_thumbnail.com"),
+                Category.of(SnowflakeUtil.nextId(), "www.herb_thumbnail.com"),
+                Category.of(SnowflakeUtil.nextId(), "www.probiotics_thumbnail.com")
         );
 
         List<CategoryInfo> categoryInfoList = Arrays.asList(
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", "비타민은 신진대사와 면역 기능을 유지하는 데 꼭 필요한 필수 영양소입니다." +
-                        "부족할 경우 피로, 면역력 저하, 피부 트러블 등 다양한 건강 문제가 발생할 수 있습니다.",  categoryList.get(0)),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", "Vitamins are chemical compounds that are needed in small amounts " +
-                        "for the human body to work correctly.",  categoryList.get(0)),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "미네랄", "미네랄은 뼈 건강, 신경 전달, 체내 수분 균형 등 다양한 생리 기능에 필수적인 영양소입니다." +
-                        "불균형하거나 부족하면 피로, 근육 경련, 면역력 저하 등이 나타날 수 있습니다.",  categoryList.get(1)),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "mineral", "Minerals are chemical elements required as an essential nutrient " +
-                        "by our body to perform essential functions. ",  categoryList.get(1)),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "허브", "허브는 자연에서 유래한 식물 성분으로, 면역 강화, 소화 개선, 스트레스 완화 등에 도움을 줍니다." +
-                        "오랜 전통과 현대 과학이 입증한 천연 건강 보조 원료로 널리 사용됩니다.",  categoryList.get(2)),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "herb", "Herbal supplements are made from plants and used for their therapeutic properties.",  categoryList.get(2)),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "유산균", "유산균은 장내 유익균을 늘려 소화 기능을 개선하고 면역력을 높여줍니다." +
-                        "장 건강은 곧 전신 건강으로 이어지며, 꾸준한 유산균 섭취가 중요합니다.",  categoryList.get(3)),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "probiotics", "Probiotics are live bacteria and yeasts that support your digestive system health. " +
-                        "We select strains that have been thoroughly studied for their benefits.",  categoryList.get(3))
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", categoryList.get(0)),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", categoryList.get(0)),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "미네랄", categoryList.get(1)),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "mineral", categoryList.get(1)),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "허브", categoryList.get(2)),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "herb", categoryList.get(2)),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "유산균", categoryList.get(3)),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "probiotics", categoryList.get(3))
         );
         // 10 비타민, 6 미네랄, 4 허브, 유산균 2
 
@@ -326,14 +319,14 @@ public class DataInitialiser implements ApplicationRunner {
                 Role.USER
         ));
 
-        Category category1 = categoryRepository.save(Category.of(1L, "www.vitamin_thumbnail.com", "www.vitamin_banner.com"));
-        Category category2 = categoryRepository.save(Category.of(2L, "www.mineral_thumbnail.com", "www.mineral_banner.com"));
+        Category category1 = categoryRepository.save(Category.of(1L, "www.vitamin_thumbnail.com"));
+        Category category2 = categoryRepository.save(Category.of(2L, "www.mineral_thumbnail.com"));
 
         categoryInfoRepository.saveAll(List.of(
-                        CategoryInfo.of(1L, Language.KO, "비타민", "비타민은 신진대사와 면역 기능을 유지하는 데 꼭 필요한 필수 영양소입니다.부족할 경우 피로, 면역력 저하, 피부 트러블 등 다양한 건강 문제가 발생할 수 있습니다.", category1),
-                        CategoryInfo.of(2L, Language.EN, "vitamin", "Vitamins are chemical compounds that are needed in small amounts for the human body to work correctly.", category1),
-                        CategoryInfo.of(3L, Language.KO, "미네랄", "미네랄은 뼈 건강, 신경 전달, 체내 수분 균형 등 다양한 생리 기능에 필수적인 영양소입니다 불균형하거나 부족하면 피로, 근육 경련, 면역력 저하 등이 나타날 수 있습니다.", category2),
-                        CategoryInfo.of(4L, Language.EN, "mineral", "Minerals are chemical elements required as an essential nutrient by our body to perform essential functions. ", category2)
+                        CategoryInfo.of(1L, Language.KO, "비타민", category1),
+                        CategoryInfo.of(2L, Language.EN, "vitamin", category1),
+                        CategoryInfo.of(3L, Language.KO, "미네랄", category2),
+                        CategoryInfo.of(4L, Language.EN, "mineral", category2)
                 )
         );
 

--- a/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
@@ -76,8 +76,7 @@ class AdminCategoryServiceTest {
     @DisplayName("새로운 카테고리 1개와 정보 1개 저장")
     void saveCategoryWithOneInfo() {
         List<AdminCategoryInfoRequest> categoryInfoRequests = List.of(new AdminCategoryInfoRequest("ko", "1번째 카테고리"));
-        AdminCategoryRequest request = new AdminCategoryRequest("www.first_banner.com",
-                "www.first_thumbnail.com", categoryInfoRequests);
+        AdminCategoryRequest request = new AdminCategoryRequest("www.first_thumbnail.com", categoryInfoRequests);
 
         adminCategoryService.saveCategories(request);
         List<Category> categories = categoryRepository.findAllCategories();
@@ -95,8 +94,7 @@ class AdminCategoryServiceTest {
         List<AdminCategoryInfoRequest> categoryInfoRequests = List.of(
                 new AdminCategoryInfoRequest("ko", "1번째 카테고리"),
                 new AdminCategoryInfoRequest("en", "first category"));
-        AdminCategoryRequest request = new AdminCategoryRequest("www.first_banner.com",
-                "www.first_thumbnail.com", categoryInfoRequests);
+        AdminCategoryRequest request = new AdminCategoryRequest("www.first_thumbnail.com", categoryInfoRequests);
 
         adminCategoryService.saveCategories(request);
         List<Category> categories = categoryRepository.findAllCategories();
@@ -182,7 +180,7 @@ class AdminCategoryServiceTest {
                 new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO"),
                 new CategoryInfoRequest(2L, Language.EN, "변경된_카테고리명_EN")
         );
-        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
+        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", infoRequests);
 
         //when //then
         assertThatThrownBy(() -> adminCategoryService.updateCategory(0L, updateRequest))
@@ -206,7 +204,7 @@ class AdminCategoryServiceTest {
                 new CategoryInfoRequest(3L, Language.KO, "변경된_카테고리명_KO"),
                 new CategoryInfoRequest(4L, Language.EN, "변경된_카테고리명_EN")
         );
-        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
+        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", infoRequests);
 
         //when //then
         assertThatThrownBy(() -> adminCategoryService.updateCategory(category.getId(), updateRequest))
@@ -228,7 +226,7 @@ class AdminCategoryServiceTest {
                 new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO"),
                 new CategoryInfoRequest(null, Language.EN, "추가된_카테고리명_EN")
         );
-        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
+        AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", infoRequests);
 
         //when
         AdminCategoryInfoResponse response = adminCategoryService.updateCategory(category.getId(), updateRequest);

--- a/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
@@ -52,10 +52,10 @@ class AdminCategoryServiceTest {
     @DisplayName("[모든 카테고리 조회] 요청한 locale 에 따라 AdminCategoryListResponse 를 페이지네이션하여 반환한다.")
     void getAllCategories_1() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", category)
         );
         categoryRepository.save(category);
         categoryInfoRepository.saveAll(categoryInfoList);
@@ -75,7 +75,7 @@ class AdminCategoryServiceTest {
     @Test
     @DisplayName("새로운 카테고리 1개와 정보 1개 저장")
     void saveCategoryWithOneInfo() {
-        List<AdminCategoryInfoRequest> categoryInfoRequests = List.of(new AdminCategoryInfoRequest("ko", "1번째 카테고리", "첫 카테고리 생성"));
+        List<AdminCategoryInfoRequest> categoryInfoRequests = List.of(new AdminCategoryInfoRequest("ko", "1번째 카테고리"));
         AdminCategoryRequest request = new AdminCategoryRequest("www.first_banner.com",
                 "www.first_thumbnail.com", categoryInfoRequests);
 
@@ -86,17 +86,15 @@ class AdminCategoryServiceTest {
         assertThat(categories.size()).isEqualTo(1);
         assertThat(categoryInfos.size()).isEqualTo(1);
         assertThat(categories.get(0).getThumbnailUrl()).isEqualTo(request.thumbnailUrl());
-        assertThat(categories.get(0).getBannerUrl()).isEqualTo(request.bannerImgUrl());
         assertThat(categoryInfos.get(0).getName()).isEqualTo(categoryInfoRequests.get(0).name());
-        assertThat(categoryInfos.get(0).getDescription()).isEqualTo(categoryInfoRequests.get(0).description());
     }
 
     @Test
     @DisplayName("새로운 카테고리 1개와 정보 2개 저장")
     void saveCategoryWithTwoInfo() {
         List<AdminCategoryInfoRequest> categoryInfoRequests = List.of(
-                new AdminCategoryInfoRequest("ko", "1번째 카테고리", "첫 카테고리 생성"),
-                new AdminCategoryInfoRequest("en", "first category", "First category created"));
+                new AdminCategoryInfoRequest("ko", "1번째 카테고리"),
+                new AdminCategoryInfoRequest("en", "first category"));
         AdminCategoryRequest request = new AdminCategoryRequest("www.first_banner.com",
                 "www.first_thumbnail.com", categoryInfoRequests);
 
@@ -107,21 +105,18 @@ class AdminCategoryServiceTest {
         assertThat(categories.size()).isEqualTo(1);
         assertThat(categoryInfos.size()).isEqualTo(2);
         assertThat(categories.get(0).getThumbnailUrl()).isEqualTo(request.thumbnailUrl());
-        assertThat(categories.get(0).getBannerUrl()).isEqualTo(request.bannerImgUrl());
         assertThat(categoryInfos.get(0).getName()).isEqualTo(categoryInfoRequests.get(0).name());
-        assertThat(categoryInfos.get(0).getDescription()).isEqualTo(categoryInfoRequests.get(0).description());
         assertThat(categoryInfos.get(1).getName()).isEqualTo(categoryInfoRequests.get(1).name());
-        assertThat(categoryInfos.get(1).getDescription()).isEqualTo(categoryInfoRequests.get(1).description());
     }
 
     @Test
     @DisplayName("[특정 카테고리 조회] 경로변수의 CategoryId 가 존재하지 않으면 에러가 발생한다.")
     void getCategoryDetails_1(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", category)
         );
         categoryRepository.save(category);
         categoryInfoRepository.saveAll(categoryInfoList);
@@ -136,10 +131,10 @@ class AdminCategoryServiceTest {
     @DisplayName("[특정 카테고리 조회] 경로변수의 CategoryId 가 존재하면 200 상태코드와 함께 AdminCategoryInfoResponse 를 반환한다.")
     void getCategoryDetails_2(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", category)
         );
         categoryRepository.save(category);
         categoryInfoRepository.saveAll(categoryInfoList);
@@ -155,10 +150,10 @@ class AdminCategoryServiceTest {
     @DisplayName("[카테고리 목록 조회] 정상적으로 카테고리 리스트를 반환한다.")
     void getCategoryList_1(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "카테고리명_EN", category)
         );
         categoryRepository.save(category);
         categoryInfoRepository.saveAll(categoryInfoList);
@@ -175,17 +170,17 @@ class AdminCategoryServiceTest {
     @DisplayName("[카테고리 수정] 경로 변수의 categoryId 가 존재하지 않는 Category 면 예외가 발생한다.")
     void updateCategory_1(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", category)
         );
         categoryRepository.save(category);
         categoryInfoRepository.saveAll(categoryInfoList);
 
         List<CategoryInfoRequest> infoRequests = List.of(
-                new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO", "변경된_설명_KO"),
-                new CategoryInfoRequest(2L, Language.EN, "변경된_카테고리명_EN", "변경된_설명_EN")
+                new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO"),
+                new CategoryInfoRequest(2L, Language.EN, "변경된_카테고리명_EN")
         );
         AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
 
@@ -199,17 +194,17 @@ class AdminCategoryServiceTest {
     @DisplayName("[카테고리 수정] CategoryInfoRequest 의 categoryInfoId 가 category 에 속해있지 않는 값이면 예외가 발생한다.")
     void updateCategory_2(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", category)
         );
         categoryRepository.save(category);
         categoryInfoRepository.saveAll(categoryInfoList);
 
         List<CategoryInfoRequest> infoRequests = List.of(
-                new CategoryInfoRequest(3L, Language.KO, "변경된_카테고리명_KO", "변경된_설명_KO"),
-                new CategoryInfoRequest(4L, Language.EN, "변경된_카테고리명_EN", "변경된_설명_EN")
+                new CategoryInfoRequest(3L, Language.KO, "변경된_카테고리명_KO"),
+                new CategoryInfoRequest(4L, Language.EN, "변경된_카테고리명_EN")
         );
         AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
 
@@ -223,15 +218,15 @@ class AdminCategoryServiceTest {
     @DisplayName("[카테고리 수정] 언어가 KO로 된 CategoryInfo 만 존재할 때 EN로 된 CategoryInfo 정보를 작성할 경우 EN 으로 된 CategoryInfo 객체가 새로 생성된다.")
     void updateCategory_3(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
-        CategoryInfo categoryInfo = CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category);
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
+        CategoryInfo categoryInfo = CategoryInfo.of(1L, Language.KO, "카테고리명_KO", category);
 
         categoryRepository.save(category);
         categoryInfoRepository.save(categoryInfo);
 
         List<CategoryInfoRequest> infoRequests = List.of(
-                new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO", "변경된_설명_KO"),
-                new CategoryInfoRequest(null, Language.EN, "추가된_카테고리명_EN", "추가된_설명_EN")
+                new CategoryInfoRequest(1L, Language.KO, "변경된_카테고리명_KO"),
+                new CategoryInfoRequest(null, Language.EN, "추가된_카테고리명_EN")
         );
         AdminCategoryUpdateRequest updateRequest = new AdminCategoryUpdateRequest("https://xxx.com/xxx", "https://xxxxx.com/xxxxx", infoRequests);
 
@@ -247,10 +242,10 @@ class AdminCategoryServiceTest {
     @DisplayName("[카테고리 삭제] 경로변수의 CategoryId 가 존재하지 않는 값일 때 예외를 반환한다.")
     void deleteCategory_1(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", category)
         );
 
         categoryRepository.save(category);
@@ -266,10 +261,10 @@ class AdminCategoryServiceTest {
     @DisplayName("[카테고리 삭제] 카테고리가 삭제될 때 그 카테고리와 관련된 상품들의 category 필드는 null 값으로 변경된다.")
     void deleteCategory_2(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", category)
         );
         Product product = Product.of(SnowflakeUtil.nextId(), 3500, 5, "https://xxxxx.com/xxxxx", category);
 
@@ -288,10 +283,10 @@ class AdminCategoryServiceTest {
     @DisplayName("[카테고리 삭제] 카테고리가 삭제될 때 그 카테고리와 관련된 CategoryInfo 객체들은 모두 DB 내에서 삭제된다.")
     void deleteCategory_3(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxxxx.com/xxxxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         List<CategoryInfo> categoryInfoList = List.of(
-                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", "설명_KO", category),
-                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", "설명_EN", category)
+                CategoryInfo.of(1L, Language.KO, "카테고리명_KO", category),
+                CategoryInfo.of(2L, Language.EN, "카테고리명_EN", category)
         );
 
         categoryRepository.save(category);

--- a/src/test/java/com/happypill/application/service/admin/AdminProductServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminProductServiceTest.java
@@ -58,7 +58,7 @@ class AdminProductServiceTest {
     @DisplayName("[특정 상품 조회] ProductPrice 가 존재하지 않으면 에러가 발생한다.")
     void getProductDetails_1() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -83,7 +83,7 @@ class AdminProductServiceTest {
     @DisplayName("[특정 상품 조회] ProductInfo 가 존재하지 않으면 에러가 발생한다.")
     void getProductDetails_2() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -105,7 +105,7 @@ class AdminProductServiceTest {
     @DisplayName("[특정 상품 조회] Product, ProductInfo, ProductPrice 가 존재하면 200 상태코드로 응답한다.")
     void getProductDetails_3() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -137,7 +137,7 @@ class AdminProductServiceTest {
     @DisplayName("[모든 상품 조회] categoryId, locale, pageable 값이 올바르게 주어졌을 때 커스텀 페이지의 contents 에는 1개의 값이 포함된다.")
     void getAllProducts_1() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -167,7 +167,7 @@ class AdminProductServiceTest {
     @DisplayName("[모든 상품 조회] categoryId 값이 null 값이 아닌 존재하지 않는 값인 경우 에러가 발생한다.")
     void getAllProducts_2() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -198,7 +198,7 @@ class AdminProductServiceTest {
     @DisplayName("[모든 상품 조회] locale 값이 en인 경우 커스텀 페이지의 contents 에는 영어로 작성된 내용들이 포함된다.")
     void getAllProducts_3() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -229,7 +229,7 @@ class AdminProductServiceTest {
     @DisplayName("[금액 기록 조회] product 와 productPrice 가 존재하는 경우 productPrice 를 반환한다.")
     void getAllProductPrices_1() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -259,7 +259,7 @@ class AdminProductServiceTest {
     @DisplayName("[금액 기록 조회]  productId 가 존재하지 않는 값인 경우 에러가 발생한다.")
     void getAllProductPrices_2() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -289,7 +289,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 등록] 한국어로 된 ProductInfo 가 없으면 에러를 반환한다.")
     void createProduct_1() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -319,7 +319,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 등록] AdminProductCreateRequest 필드 모두 유효하면 ProductId 를 반환한다.")
     void createProduct_2() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx", " https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), " https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, " https://xxx.com/xxx", false, category);
@@ -351,7 +351,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 등록] Category 가 존재하지 않으면 에러를 반환한다.")
     void createProduct_4() {
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, "https://xxx.com/xxx", false, category);
@@ -382,7 +382,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 수정] 경로 변수의 productId가 존재하지 않는 Product 면 에러를 반환한다.")
     void updateProduct_1(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, "https://xxx.com/xxx", false, category);
@@ -413,7 +413,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 수정] price 수정 시 기존의 ProductPrice 엔티티의 isUsed 필드는 false 로 설정하고 새로운 ProductPrice 를 생성한다.")
     void updateProduct_2(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, "https://xxx.com/xxx", false, category);
@@ -450,7 +450,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 수정] 기존에 한국어와 영어로 된 ProductInfo 가 있을 때 한국어로 된 ProductInfo 만 수정 시 영어로 된 ProductInfo 는 수정되지 않고 한국어로 된 ProductInfo 만 수정된다.")
     void updateProduct_3(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, "https://xxx.com/xxx", false, category);
@@ -484,7 +484,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 삭제] 경로 변수의 productId가 존재하지 않는 Product면 에러를 반환한다.")
     void deleteProduct_1(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, "https://xxx.com/xxx", false, category);
@@ -500,7 +500,7 @@ class AdminProductServiceTest {
     @DisplayName("[상품 삭제] 상품이 삭제되면 isAvailable 은 false, isDeleted 는 true 가 된다.")
     void deleteProduct_2(){
         //given
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         categoryRepository.save(category);
 
         Product product = Product.of(SnowflakeUtil.nextId(), 1000, 3, true, "https://xxx.com/xxx", false, category);

--- a/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
@@ -198,7 +198,7 @@ class AdminUserServiceTest {
         HappypillUser savedUser = generateTestUser();
         userRepository.save(savedUser);
 
-        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx", "https://xxx.com/xxx");
+        Category category = Category.of(SnowflakeUtil.nextId(), "https://xxx.com/xxx");
         categoryRepository.save(category);
 
         List<Product> products = List.of(

--- a/src/test/java/com/happypill/application/service/category/CategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/category/CategoryServiceTest.java
@@ -40,10 +40,10 @@ public class CategoryServiceTest {
     @DisplayName("카테고리 있을 때 불러오기 테스트")
     public void shouldReturnCategories() {
         Locale locale = Locale.of("KO");
-        Category category = Category.of(1L, "first thum url", "first banner url");
+        Category category = Category.of(1L, "first thum url");
         List<CategoryInfo> categoryResponses = Arrays.asList(
-                CategoryInfo.of(1L, Language.KO, "first name", "first desc", category),
-                CategoryInfo.of(2L, Language.KO, "second name", "second desc", category)
+                CategoryInfo.of(1L, Language.KO, "first name", category),
+                CategoryInfo.of(2L, Language.KO, "second name", category)
         );
 
         categoryRepository.save(category);

--- a/src/test/java/com/happypill/application/service/order/OrderServiceTest.java
+++ b/src/test/java/com/happypill/application/service/order/OrderServiceTest.java
@@ -62,7 +62,7 @@ class OrderServiceTest {
     void test1() {
         HappypillUser savedTestUser = getSavedTestUser();
         SecurityUserContext userContext = SecurityUserContext.from(savedTestUser.getId());
-        Category category = categoryRepository.save(Category.of(SnowflakeUtil.nextId(), "www.happypill.com/image", "www.happypill.com/banner"));
+        Category category = categoryRepository.save(Category.of(SnowflakeUtil.nextId(), "www.happypill.com/image"));
         Product product1 = productRepository.save(Product.of(SnowflakeUtil.nextId(), 1000, 100, "www.happypill.com/product1-thumbnail", category));
         Product product2 = productRepository.save(Product.of(SnowflakeUtil.nextId(), 2000, 200, "www.happypill.com/product2-thumbnail", category));
         var orderLineCreateRequest1 = new OrderCreateRequest.OrderLineCreateRequest(product1.getId(), 3, LocalDate.of(2026, 1, 1));

--- a/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
+++ b/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
@@ -55,13 +55,13 @@ public class ProductServiceTest {
 
     @BeforeEach
     void setUpDB() {
-        Category categoryOne = Category.of(SnowflakeUtil.nextId(), "www.category_firstThumbnail.com", "www.category_firstBanner.com");
-        Category categoryTwo = Category.of(SnowflakeUtil.nextId(), "www.category_secondThumbnail.com", "www.category_secondBanner.com");
+        Category categoryOne = Category.of(SnowflakeUtil.nextId(), "www.category_firstThumbnail.com");
+        Category categoryTwo = Category.of(SnowflakeUtil.nextId(), "www.category_secondThumbnail.com");
         List<Category> categoryList = Arrays.asList(categoryOne, categoryTwo);
 
-        CategoryInfo categoryInfoOne = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", "비타민은 몸에 좋아요",  categoryOne);
-        CategoryInfo categoryInfoTwo = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", "vitamin is necessary for health",  categoryOne);
-        CategoryInfo categoryInfoThree = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분", "몸이 튼튼해져요",  categoryTwo);
+        CategoryInfo categoryInfoOne = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", categoryOne);
+        CategoryInfo categoryInfoTwo = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", categoryOne);
+        CategoryInfo categoryInfoThree = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분", categoryTwo);
         List<CategoryInfo> categoryInfoList = Arrays.asList(categoryInfoOne, categoryInfoTwo, categoryInfoThree);
 
         Product productOne = Product.of(SnowflakeUtil.nextId(), 25000, 300, "www.product_firstThumbnail.com", categoryOne);


### PR DESCRIPTION
# 티켓
HP-131

# 설명
- Category 엔티티의 bannerUrl 필드 삭제
- CategoryInfo 엔티티의 description 필드 삭제

## 타입
- [ ] 버그
- [ ] 작업
- [x] 기능 향상

# 테스트 방법
테스트 없음

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [ ] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 카테고리 및 카테고리 정보 관련 API에서 배너 이미지 URL과 설명 필드가 제거되어, 더 간결한 데이터 구조로 변경되었습니다.

* **Bug Fixes**
  * 관련 요청 및 응답 객체, 테스트 코드에서 불필요한 필드(배너 이미지, 설명) 제거로 일관성 및 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->