### PR TITLE
HP-145 : [관리자] 회원 계정 비활성화/복구 endpoint

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
@@ -56,4 +56,11 @@ public class AdminUserController {
         Pageable pageable = PageRequest.of(page - 1, size);
         return adminUserService.getAllSubscriptions(pageable, locale);
     }
+
+    @Operation(summary = "회원 계정 비활성화/복구", description = "회원 계정을 탈퇴 처리하거나 복구하기 위한 API")
+    @PatchMapping("/{userId}/status")
+    //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
+    public AdminUserDetailResponse updateUserStatus(@PathVariable Long userId){
+        return adminUserService.updateUserStatus(userId);
+    }
 }

--- a/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
@@ -57,10 +57,17 @@ public class AdminUserController {
         return adminUserService.getAllSubscriptions(pageable, locale);
     }
 
-    @Operation(summary = "회원 계정 비활성화/복구", description = "회원 계정을 탈퇴 처리하거나 복구하기 위한 API")
-    @PatchMapping("/{userId}/status")
+    @Operation(summary = "회원 계정 활성화", description = "회원 계정을 활성화하기 위한 API")
+    @PatchMapping("/{userId}/activate")
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
-    public AdminUserDetailResponse updateUserStatus(@PathVariable Long userId){
-        return adminUserService.updateUserStatus(userId);
+    public AdminUserDetailResponse activateUser(@PathVariable Long userId){
+        return adminUserService.activateUser(userId);
+    }
+
+    @Operation(summary = "회원 계정 비활성화", description = "회원 계정을 비활성화하기 위한 API")
+    @PatchMapping("/{userId}/deactivate")
+    //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
+    public AdminUserDetailResponse deactivateUser(@PathVariable Long userId){
+        return adminUserService.deactivateUser(userId);
     }
 }

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -54,4 +54,12 @@ public class HappypillUser extends BaseEntity<Long> {
     public void changeNotifyEmail(String notifyEmail) {
         this.notifyEmail = notifyEmail;
     }
+
+    public void deactivate() {
+        this.isDeleted = true;
+    }
+
+    public void restore() {
+        this.isDeleted = false;
+    }
 }

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -59,7 +59,7 @@ public class HappypillUser extends BaseEntity<Long> {
         this.isDeleted = true;
     }
 
-    public void restore() {
+    public void activate() {
         this.isDeleted = false;
     }
 }

--- a/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
+++ b/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
@@ -28,7 +28,10 @@ public enum ExceptionCode {
     CATEGORY_NOT_FOUND(NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
 
     // 카테고리 정보
-    CATEGORY_INFO_NOT_FOUND(NOT_FOUND, "해당 카테고리 정보를 찾을 수 없습니다");
+    CATEGORY_INFO_NOT_FOUND(NOT_FOUND, "해당 카테고리 정보를 찾을 수 없습니다"),
+
+    USER_ALREADY_DELETED(BAD_REQUEST, "이미 삭제된 회원입니다."),
+    USER_NOT_DELETED(BAD_REQUEST, "삭제되지 않은 회원입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/happypill/application/service/admin/AdminUserService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminUserService.java
@@ -71,18 +71,31 @@ public class AdminUserService {
         return new CustomPage<>(responses);
     }
 
-    //회원 계정 비활성화/복구
+    //회원 계정 활성화
     @Transactional
-    public AdminUserDetailResponse updateUserStatus(Long userId){
+    public AdminUserDetailResponse activateUser(Long userId){
+        HappypillUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+
+        if(!user.isDeleted()) {
+            throw new BusinessException(ExceptionCode.USER_NOT_DELETED);
+        }
+
+        user.activate();
+        return AdminUserDetailResponse.from(user);
+    }
+
+    //회원 계정 비활성화
+    @Transactional
+    public AdminUserDetailResponse deactivateUser(Long userId){
         HappypillUser user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
 
         if(user.isDeleted()) {
-            user.restore();
-        } else {
-            user.deactivate();
+            throw new BusinessException(ExceptionCode.USER_ALREADY_DELETED);
         }
 
+        user.deactivate();
         return AdminUserDetailResponse.from(user);
     }
 

--- a/src/main/java/com/happypill/application/service/admin/AdminUserService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminUserService.java
@@ -71,6 +71,21 @@ public class AdminUserService {
         return new CustomPage<>(responses);
     }
 
+    //회원 계정 비활성화/복구
+    @Transactional
+    public AdminUserDetailResponse updateUserStatus(Long userId){
+        HappypillUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+
+        if(user.isDeleted()) {
+            user.restore();
+        } else {
+            user.deactivate();
+        }
+
+        return AdminUserDetailResponse.from(user);
+    }
+
     private void updateNickname(HappypillUser user, AdminUserUpdateRequest request){
         String newNickname = request.nickName();
         if(newNickname != null && !newNickname.isBlank()){

--- a/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
@@ -247,44 +247,84 @@ class AdminUserServiceTest {
     }
 
     @Test
-    @DisplayName("[회원 계정 비활성화/복구] 경로 변수의 userId 가 존재하지 않는 회원일 경우 예외를 반환한다.")
-    void updateUserStatus_1() {
+    @DisplayName("[회원 계정 활성화] 경로 변수의 userId 가 존재하지 않는 회원일 경우 예외를 반환한다.")
+    void activateUser_1() {
         //given
         HappypillUser user = generateTestUser();
         userRepository.save(user);
 
         //when //then
-        assertThatThrownBy(() -> adminUserService.updateUserStatus(0L))
+        assertThatThrownBy(() -> adminUserService.activateUser(0L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ExceptionCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
-    @DisplayName("[회원 계정 비활성화/복구] 회원을 비활성화 시 isDeleted 필드는 true 로 수정된다.")
-    void updateUserStatus_2() {
+    @DisplayName("[회원 계정 활성화] 회원 계정이 이미 활성화된 경우 이를 활성화하려고 하면 예외를 반환한다.")
+    void activateUser_2() {
         //given
         HappypillUser user = generateTestUser();
         userRepository.save(user);
 
-        //when
-        adminUserService.updateUserStatus(user.getId());
-
-        //then
-        assertThat(user.isDeleted()).isTrue();
+        //when //then
+        assertThatThrownBy(() -> adminUserService.activateUser(user.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_NOT_DELETED.getMessage());
     }
 
     @Test
-    @DisplayName("[회원 계정 비활성화/복구] 회원을 복구 시 isDeleted 필드는 false 로 수정된다.")
-    void updateUserStatus_3() {
+    @DisplayName("[회원 계정 활성화] 회원을 활성화 시 isDeleted 필드는 false 로 수정된다.")
+    void activateUser_3() {
         //given
         HappypillUser user = generateTestUser();
         user.deactivate();
         userRepository.save(user);
 
         //when
-        adminUserService.updateUserStatus(user.getId());
+        adminUserService.activateUser(user.getId());
 
         //then
         assertThat(user.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("[회원 계정 비활성화] 경로 변수의 userId 가 존재하지 않는 회원일 경우 예외를 반환한다.")
+    void deactivateUser_1() {
+        //given
+        HappypillUser user = generateTestUser();
+        userRepository.save(user);
+
+        //when //then
+        assertThatThrownBy(() -> adminUserService.deactivateUser(0L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("[회원 계정 비활성화] 회원 계정이 이미 비활성화된 경우 이를 비활성화하려고 하면 예외를 반환한다.")
+    void deactivateUser_2() {
+        //given
+        HappypillUser user = generateTestUser();
+        user.deactivate();
+        userRepository.save(user);
+
+        //when //then
+        assertThatThrownBy(() -> adminUserService.deactivateUser(user.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("[회원 계정 비활성화] 회원을 비활성화 시 isDeleted 필드는 true 로 수정된다.")
+    void deactivateUser_3() {
+        //given
+        HappypillUser user = generateTestUser();
+        userRepository.save(user);
+
+        //when
+        adminUserService.deactivateUser(user.getId());
+
+        //then
+        assertThat(user.isDeleted()).isTrue();
     }
 }

--- a/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminUserServiceTest.java
@@ -245,4 +245,46 @@ class AdminUserServiceTest {
                 .extracting(AdminSubscriptionListResponse::getSubscriptionId)
                 .contains(String.valueOf(subscriptions.get(0).getId()));
     }
+
+    @Test
+    @DisplayName("[회원 계정 비활성화/복구] 경로 변수의 userId 가 존재하지 않는 회원일 경우 예외를 반환한다.")
+    void updateUserStatus_1() {
+        //given
+        HappypillUser user = generateTestUser();
+        userRepository.save(user);
+
+        //when //then
+        assertThatThrownBy(() -> adminUserService.updateUserStatus(0L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("[회원 계정 비활성화/복구] 회원을 비활성화 시 isDeleted 필드는 true 로 수정된다.")
+    void updateUserStatus_2() {
+        //given
+        HappypillUser user = generateTestUser();
+        userRepository.save(user);
+
+        //when
+        adminUserService.updateUserStatus(user.getId());
+
+        //then
+        assertThat(user.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[회원 계정 비활성화/복구] 회원을 복구 시 isDeleted 필드는 false 로 수정된다.")
+    void updateUserStatus_3() {
+        //given
+        HappypillUser user = generateTestUser();
+        user.deactivate();
+        userRepository.save(user);
+
+        //when
+        adminUserService.updateUserStatus(user.getId());
+
+        //then
+        assertThat(user.isDeleted()).isFalse();
+    }
 }


### PR DESCRIPTION
# 티켓
HP-145

# 설명
![image](https://github.com/user-attachments/assets/ba8ca601-cbc5-44e6-afb6-4568369cddb7)

- 관리자가 회원 계정을 비활성화/복구 하는 엔드포인트 생성

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합 테스트 및 postman 으로 데이터 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 사용자의 계정 상태(활성화/비활성화)를 개별적으로 전환할 수 있는 API 엔드포인트가 추가되었습니다.

* **테스트**
  * 사용자 계정 활성화 및 비활성화 기능에 대한 테스트가 추가되어 정상 동작과 예외 처리가 검증되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->