### PR TITLE
HP-147 : [메인페이지] 모든 상품 조회 리팩토링

### DIFF
--- a/src/main/java/com/happypill/api/controller/ProductController.java
+++ b/src/main/java/com/happypill/api/controller/ProductController.java
@@ -1,10 +1,7 @@
 package com.happypill.api.controller;
 
 import com.happypill.application.service.product.ProductService;
-import com.happypill.application.service.product.response.CustomPageResponse;
-import com.happypill.application.service.product.response.ProductInfoResponse;
-import com.happypill.application.service.product.response.ProductResponse;
-import com.happypill.application.service.product.response.ProductRelatedResponse;
+import com.happypill.application.service.product.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +20,11 @@ public class ProductController {
 
     @Operation(summary = "모든 상품 조회", description = "상품 목록들을 더보기 형식으로 조회합니다.")
     @GetMapping
-    public CustomPageResponse<ProductResponse> getProducts(@RequestParam Long categoryId, @RequestParam(required = false) Long lastProductId,
-                                                           Locale locale, @RequestParam int size) {
-        return productService.getAllProducts(categoryId, lastProductId, locale, size);
+    public CustomPageResponse<ProductListResponse> getProducts(@RequestParam(required = false) Long categoryId,
+                                                               @RequestParam(required = false) Long lastProductId,
+                                                               @RequestParam(defaultValue = "3") int size,
+                                                               Locale locale) {
+        return productService.loadAllProducts(categoryId, lastProductId, size, locale);
     }
 
     @Operation(summary = "특정 상품 조회", description = "특정 상품을 조회합니다.")

--- a/src/main/java/com/happypill/api/controller/ProductController.java
+++ b/src/main/java/com/happypill/api/controller/ProductController.java
@@ -15,14 +15,14 @@ import java.util.Locale;
 @RequiredArgsConstructor
 @RequestMapping("/api/products")
 public class ProductController {
-    private static final String LANGUAGE_HEADER = "Language";
+
     private final ProductService productService;
 
     @Operation(summary = "모든 상품 조회", description = "상품 목록들을 더보기 형식으로 조회합니다.")
     @GetMapping
     public CustomPageResponse<ProductListResponse> getProducts(@RequestParam(required = false) Long categoryId,
                                                                @RequestParam(required = false) Long lastProductId,
-                                                               @RequestParam(defaultValue = "3") int size,
+                                                               @RequestParam int size,
                                                                Locale locale) {
         return productService.loadAllProducts(categoryId, lastProductId, size, locale);
     }

--- a/src/main/java/com/happypill/application/repository/product/ProductRepository.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepository.java
@@ -14,7 +14,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
     @Query("""
             SELECT pi
             FROM ProductInfo pi

--- a/src/main/java/com/happypill/application/repository/product/ProductRepositoryCustom.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.happypill.application.repository.product;
+
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.service.product.response.ProductListResponse;
+
+import java.util.List;
+
+public interface ProductRepositoryCustom {
+    List<ProductListResponse> findAllProductsByLanguage(Long categoryId, Long lastProductId, int size, Language language);
+}

--- a/src/main/java/com/happypill/application/repository/product/ProductRepositoryCustom.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepositoryCustom.java
@@ -6,5 +6,5 @@ import com.happypill.application.service.product.response.ProductListResponse;
 import java.util.List;
 
 public interface ProductRepositoryCustom {
-    List<ProductListResponse> findAllProductsByLanguage(Long categoryId, Long lastProductId, int size, Language language);
+    List<ProductListResponse> scrollProductsByLanguageAndCategoryWithBestProduct(Long categoryId, Long lastProductId, int size, Language language);
 }

--- a/src/main/java/com/happypill/application/repository/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepositoryImpl.java
@@ -25,16 +25,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<ProductListResponse> findAllProductsByLanguage(Long categoryId, Long lastProductId, int size, Language language) {
-        Boolean lastIsBest = null; //이전 요청에서 받은 lastProductId 가 bestProduct 에 포함된 상품인지 여부
-        if (lastProductId != null) {
-            lastIsBest = jpaQueryFactory
-                    .selectOne()
-                    .from(bestProduct)
-                    .where(bestProduct.product.id.eq(lastProductId)) //lastProductId 가 bestProduct 에 포함되어있는지 필터 적용
-                    .fetchFirst() != null;
-        }
-
+    public List<ProductListResponse> scrollProductsByLanguageAndCategoryWithBestProduct(Long categoryId, Long lastProductId, int size, Language language) {
         BooleanBuilder baseCondition = new BooleanBuilder();
         baseCondition.and(product.isAvailable.isTrue());
 
@@ -42,16 +33,17 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             baseCondition.and(category.id.eq(categoryId));
         }
 
-        if (lastProductId != null && lastIsBest != null) { //첫 번째 요청 이후 적용
-            BooleanExpression isBestExpr = bestProduct.id.isNotNull();
-            BooleanExpression cursorCondition;
+        if (lastProductId != null) {
+            boolean lastIsBest = jpaQueryFactory
+                    .selectOne()
+                    .from(bestProduct)
+                    .where(bestProduct.product.id.eq(lastProductId))
+                    .fetchFirst() != null;
 
-            if (Boolean.TRUE.equals(lastIsBest)) { //isBest = true 이면서 product.id < lastProductId 인 데이터 출력 또는 isBest = false 인 데이터 출력
-                cursorCondition = isBestExpr.and(product.id.lt(lastProductId))
-                        .or(isBestExpr.not());
-            } else { //이전 상품이 bestProduct 가 아니었다면 isBest = false 이면서 product.id < lastProductId 만 출력
-                cursorCondition = isBestExpr.not().and(product.id.lt(lastProductId));
-            }
+            BooleanExpression isBestExpr = bestProduct.id.isNotNull();
+            BooleanExpression cursorCondition = lastIsBest
+                    ? isBestExpr.and(product.id.lt(lastProductId)).or(isBestExpr.not())
+                    : isBestExpr.not().and(product.id.lt(lastProductId));
 
             baseCondition.and(cursorCondition);
         }
@@ -69,10 +61,19 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         bestProduct.id.isNotNull()
                 ))
                 .from(product)
-                .join(productInfo).on(productInfo.product.eq(product).and(productInfo.language.eq(language)))
+                .join(productInfo)
+                    .on(
+                            productInfo.product.eq(product)
+                                .and(productInfo.language.eq(language))
+                    )
                 .join(product.category, category)
-                .join(categoryInfo).on(categoryInfo.category.eq(category).and(categoryInfo.language.eq(language)))
-                .leftJoin(bestProduct).on(bestProduct.product.eq(product))
+                .join(categoryInfo)
+                    .on(
+                            categoryInfo.category.eq(category)
+                                .and(categoryInfo.language.eq(language))
+                    )
+                .leftJoin(bestProduct)
+                    .on(bestProduct.product.eq(product))
                 .where(baseCondition)
                 .orderBy(
                         new CaseBuilder()

--- a/src/main/java/com/happypill/application/repository/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/product/ProductRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.happypill.application.repository.product;
+
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.service.product.response.ProductListResponse;
+import com.happypill.application.service.product.response.QProductListResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.happypill.application.entity.QBestProduct.bestProduct;
+import static com.happypill.application.entity.QCategory.category;
+import static com.happypill.application.entity.QCategoryInfo.categoryInfo;
+import static com.happypill.application.entity.QProduct.product;
+import static com.happypill.application.entity.QProductInfo.productInfo;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ProductListResponse> findAllProductsByLanguage(Long categoryId, Long lastProductId, int size, Language language) {
+        Boolean lastIsBest = null; //이전 요청에서 받은 lastProductId 가 bestProduct 에 포함된 상품인지 여부
+        if (lastProductId != null) {
+            lastIsBest = jpaQueryFactory
+                    .selectOne()
+                    .from(bestProduct)
+                    .where(bestProduct.product.id.eq(lastProductId)) //lastProductId 가 bestProduct 에 포함되어있는지 필터 적용
+                    .fetchFirst() != null;
+        }
+
+        BooleanBuilder baseCondition = new BooleanBuilder();
+        baseCondition.and(product.isAvailable.isTrue());
+
+        if (categoryId != null) {
+            baseCondition.and(category.id.eq(categoryId));
+        }
+
+        if (lastProductId != null && lastIsBest != null) { //첫 번째 요청 이후 적용
+            BooleanExpression isBestExpr = bestProduct.id.isNotNull();
+            BooleanExpression cursorCondition;
+
+            if (Boolean.TRUE.equals(lastIsBest)) { //isBest = true 이면서 product.id < lastProductId 인 데이터 출력 또는 isBest = false 인 데이터 출력
+                cursorCondition = isBestExpr.and(product.id.lt(lastProductId))
+                        .or(isBestExpr.not());
+            } else { //이전 상품이 bestProduct 가 아니었다면 isBest = false 이면서 product.id < lastProductId 만 출력
+                cursorCondition = isBestExpr.not().and(product.id.lt(lastProductId));
+            }
+
+            baseCondition.and(cursorCondition);
+        }
+
+        return jpaQueryFactory
+                .select(new QProductListResponse(
+                        product.id.stringValue(),
+                        category.id.stringValue(),
+                        productInfo.name,
+                        categoryInfo.name,
+                        productInfo.company,
+                        product.price,
+                        productInfo.briefDescription,
+                        product.thumbnailUrl,
+                        bestProduct.id.isNotNull()
+                ))
+                .from(product)
+                .join(productInfo).on(productInfo.product.eq(product).and(productInfo.language.eq(language)))
+                .join(product.category, category)
+                .join(categoryInfo).on(categoryInfo.category.eq(category).and(categoryInfo.language.eq(language)))
+                .leftJoin(bestProduct).on(bestProduct.product.eq(product))
+                .where(baseCondition)
+                .orderBy(
+                        new CaseBuilder()
+                                .when(bestProduct.id.isNotNull()).then(1)
+                                .otherwise(0)
+                                .desc(),
+                        product.id.desc()
+                )
+                .limit(size + 1)
+                .fetch();
+    }
+}

--- a/src/main/java/com/happypill/application/service/product/ProductService.java
+++ b/src/main/java/com/happypill/application/service/product/ProductService.java
@@ -10,7 +10,6 @@ import com.happypill.application.repository.productprice.ProductPriceRepository;
 import com.happypill.application.service.product.response.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/com/happypill/application/service/product/ProductService.java
+++ b/src/main/java/com/happypill/application/service/product/ProductService.java
@@ -64,7 +64,7 @@ public class ProductService {
     public CustomPageResponse<ProductListResponse> loadAllProducts(Long categoryId, Long lastProductId, int size, Locale locale) {
         Language language = Language.parseLanguage(locale.getLanguage());
 
-        List<ProductListResponse> content = productRepository.findAllProductsByLanguage(categoryId, lastProductId, size, language);
+        List<ProductListResponse> content = productRepository.scrollProductsByLanguageAndCategoryWithBestProduct(categoryId, lastProductId, size, language);
 
         boolean hasNext = content.size() > size;
 

--- a/src/main/java/com/happypill/application/service/product/ProductService.java
+++ b/src/main/java/com/happypill/application/service/product/ProductService.java
@@ -7,12 +7,10 @@ import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.product.ProductRepository;
 import com.happypill.application.repository.productprice.ProductPriceRepository;
-import com.happypill.application.service.product.response.CustomPageResponse;
-import com.happypill.application.service.product.response.ProductInfoResponse;
-import com.happypill.application.service.product.response.ProductResponse;
-import com.happypill.application.service.product.response.ProductRelatedResponse;
+import com.happypill.application.service.product.response.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 
 import java.time.ZonedDateTime;
@@ -27,6 +25,10 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final ProductPriceRepository productPriceRepository;
 
+    /**
+     * loadAllProducts 메소드로 대체됨
+     */
+    @Deprecated
     public CustomPageResponse<ProductResponse> getAllProducts(Long categoryId, Long lastProductId, Locale locale, int size) {
         Language language = Language.parseLanguage(locale.getLanguage());
         List<ProductInfo> productInfos;
@@ -58,6 +60,20 @@ public class ProductService {
         );
 
         return response;
+    }
+
+    public CustomPageResponse<ProductListResponse> loadAllProducts(Long categoryId, Long lastProductId, int size, Locale locale) {
+        Language language = Language.parseLanguage(locale.getLanguage());
+
+        List<ProductListResponse> content = productRepository.findAllProductsByLanguage(categoryId, lastProductId, size, language);
+
+        boolean hasNext = content.size() > size;
+
+        List<ProductListResponse> result = hasNext ? content.subList(0, size) : content;
+
+        Long nextLastProductId = result.isEmpty() ? null : Long.valueOf(result.getLast().getProductId());
+
+        return new CustomPageResponse<>(result, hasNext, nextLastProductId);
     }
 
     public ProductInfoResponse getProduct(Long productId, Locale locale) {

--- a/src/main/java/com/happypill/application/service/product/response/ProductListResponse.java
+++ b/src/main/java/com/happypill/application/service/product/response/ProductListResponse.java
@@ -1,0 +1,32 @@
+package com.happypill.application.service.product.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
+
+@NoArgsConstructor
+@Setter
+@Getter
+public class ProductListResponse {
+    private String productId;
+    private String categoryId;
+    private String productName;
+    private String categoryName;
+    private String company;
+    private int price;
+    private String briefDescription;
+    private String thumbnailUrl;
+    private boolean isBest;
+
+    @QueryProjection
+    public ProductListResponse(String productId, String categoryId, String productName, String categoryName, String company, int price, String briefDescription, String thumbnailUrl, boolean isBest) {
+        this.productId = productId;
+        this.categoryId = categoryId;
+        this.productName = productName;
+        this.categoryName = categoryName;
+        this.company = company;
+        this.price = price;
+        this.briefDescription = briefDescription;
+        this.thumbnailUrl = thumbnailUrl;
+        this.isBest = isBest;
+    }
+}

--- a/src/main/java/com/happypill/application/service/product/response/ProductListResponse.java
+++ b/src/main/java/com/happypill/application/service/product/response/ProductListResponse.java
@@ -4,7 +4,6 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 
 @NoArgsConstructor
-@Setter
 @Getter
 public class ProductListResponse {
     private String productId;

--- a/src/main/java/com/happypill/application/util/DataInitialiser.java
+++ b/src/main/java/com/happypill/application/util/DataInitialiser.java
@@ -5,6 +5,7 @@ import com.happypill.application.entity.enums.Language;
 import com.happypill.application.entity.enums.PaymentMethod;
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
+import com.happypill.application.repository.bestproduct.BestProductRepository;
 import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
@@ -35,6 +36,8 @@ public class DataInitialiser implements ApplicationRunner {
 
     private final HappypillUserRepository userRepository;
     private final OrderRepository orderRepository;
+
+    private final BestProductRepository bestProductRepository;
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
@@ -313,6 +316,8 @@ public class DataInitialiser implements ApplicationRunner {
         productPriceRepository.saveAll(productPriceList);
 
         generateDevData();
+
+        createBestProduct(productList.subList(0, 10));
     }
 
     private void generateDevData() {
@@ -370,5 +375,13 @@ public class DataInitialiser implements ApplicationRunner {
                 )
         ));
 
+    }
+
+    private void createBestProduct(List<Product> product) {
+        List<BestProduct> bestProducts = product.stream()
+                .map(p -> BestProduct.of(SnowflakeUtil.nextId(), p))
+                .toList();
+
+        bestProductRepository.saveAll(bestProducts);
     }
 }

--- a/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
+++ b/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
@@ -1,21 +1,16 @@
 package com.happypill.application.service.product;
 
-import com.happypill.application.entity.Category;
-import com.happypill.application.entity.CategoryInfo;
-import com.happypill.application.entity.Product;
-import com.happypill.application.entity.ProductInfo;
+import com.happypill.application.entity.*;
 import com.happypill.application.entity.enums.Language;
 import com.happypill.application.exception.custom.ExceptionCode;
 import com.happypill.application.exception.global.BusinessException;
+import com.happypill.application.repository.bestproduct.BestProductRepository;
 import com.happypill.application.repository.category.CategoryRepository;
 import com.happypill.application.repository.categoryinfo.CategoryInfoRepository;
 import com.happypill.application.repository.product.ProductRepository;
 import com.happypill.application.repository.productinfo.ProductInfoRepository;
 import com.happypill.application.repository.productprice.ProductPriceRepository;
-import com.happypill.application.service.product.response.CustomPageResponse;
-import com.happypill.application.service.product.response.ProductInfoResponse;
-import com.happypill.application.service.product.response.ProductResponse;
-import com.happypill.application.service.product.response.ProductRelatedResponse;
+import com.happypill.application.service.product.response.*;
 import com.happypill.application.util.SnowflakeUtil;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +44,9 @@ public class ProductServiceTest {
 
     @Autowired
     private ProductInfoRepository productInfoRepository;
+
+    @Autowired
+    private BestProductRepository bestProductRepository;
 
     @Autowired
     private ProductService productService;
@@ -93,6 +91,7 @@ public class ProductServiceTest {
 
     @AfterEach
     void clearDB() {
+        bestProductRepository.deleteAll();
         productPriceRepository.deleteAll();
         productInfoRepository.deleteAll();
         productRepository.deleteAll();
@@ -231,5 +230,152 @@ public class ProductServiceTest {
         assertThat(recommendations.getLast().productId()).isEqualTo(lastProduct.getId().toString());
         assertThat(recommendations.getLast().thumbnailUrl()).isEqualTo(lastProduct.getThumbnailUrl());
         assertThat(recommendations.getLast().price()).isEqualTo(lastProduct.getPrice());
+    }
+
+    @Test
+    @DisplayName("[모든 상품 조회] 상품 리스트가 size 보다 작을 때 hasNext = false 가 출력된다.")
+    void loadAllProducts_1() {
+        //given
+        clearDB();
+
+        Category categoryOne = Category.of(SnowflakeUtil.nextId(), "www.category_firstThumbnail.com", "www.category_firstBanner.com");
+        Category categoryTwo = Category.of(SnowflakeUtil.nextId(), "www.category_secondThumbnail.com", "www.category_secondBanner.com");
+        List<Category> categoryList = Arrays.asList(categoryOne, categoryTwo);
+
+        CategoryInfo categoryInfoOne = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", "비타민은 몸에 좋아요",  categoryOne);
+        CategoryInfo categoryInfoTwo = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", "vitamin is necessary for health",  categoryOne);
+        CategoryInfo categoryInfoThree = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분", "몸이 튼튼해져요", categoryTwo);
+        CategoryInfo categoryInfoFour = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "Iron", "Helps strengthen the body", categoryTwo);
+        List<CategoryInfo> categoryInfoList = Arrays.asList(categoryInfoOne, categoryInfoTwo, categoryInfoThree, categoryInfoFour);
+
+        Product productOne = Product.of(SnowflakeUtil.nextId(), 25000, 300, "www.product_firstThumbnail.com", categoryOne);
+        Product productTwo = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryOne);
+        Product productThree = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryOne);
+        Product productFour = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryOne);
+        Product productFive = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+        Product productSix = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+        Product productSeven = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+        Product productEight = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+
+        List<Product> productList = Arrays.asList(productOne, productTwo, productThree, productFour, productFive, productSix, productSeven, productEight);
+        List<Product> bestProductList = Arrays.asList(productOne, productTwo, productFive);
+
+        ProductInfo productInfoOne = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 C", "30 캡슐", "밥과 함께 드시오", "물과 함께 섭취하시오. 하루에 3개.", "Content image", "매우 강력한 마법의 알약", "삼성제약", "오줌이 노래져요", productOne);
+        ProductInfo productInfoTwo = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin C", "30 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productOne);
+        ProductInfo productInfoThree = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 K", "10 캡슐", "밥과 함께 3알 드세요", "과대 섭취 금지", "Content image", "매우 화려한 알약", "삼성제약", "이건 어디 좋은지 몰라요 저희도", productTwo);
+        ProductInfo productInfoFour = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin K", "10 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productTwo);
+        ProductInfo productInfoFive = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 K", "10 캡슐", "밥과 함께 3알 드세요", "과대 섭취 금지", "Content image", "매우 화려한 알약", "삼성제약", "이건 어디 좋은지 몰라요 저희도", productThree);
+        ProductInfo productInfoSix = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin K", "10 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productThree);
+        ProductInfo productInfoSeven = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 D", "15 캡슐", "하루에 한 알", "햇빛 대신 섭취하세요", "Content image", "뼈에 좋아요", "삼성제약", "과다 복용 금지", productFour);
+        ProductInfo productInfoEight = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin D", "15 capsules", "Once a day", "Take as sunlight replacement", "Content image", "Good for bones", "Samsung chemist", "Do not overdose", productFour);
+        ProductInfo productInfoNine = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분제", "60 정", "식후 복용", "변비 유발 주의", "Content image", "빈혈에 도움", "삼성제약", "과다 복용 금지", productFive);
+        ProductInfo productInfoTen = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Iron Pill", "60 tablets", "After meal", "May cause constipation", "Content image", "Helps with anemia", "Samsung chemist", "Do not overdose", productFive);
+        ProductInfo productInfoEleven = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "오메가3", "90 정", "식후 복용", "기름기 많음", "Content image", "혈관 건강에 도움", "삼성제약", "임산부는 복용 전 의사 상담", productSix);
+        ProductInfo productInfoTwelve = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Omega-3", "90 tablets", "After meal", "High in fat", "Content image", "Supports heart health", "Samsung chemist", "Consult doctor if pregnant", productSix);
+        ProductInfo productInfoThirteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "루테인", "30 정", "하루 한 알", "눈에 도움", "Content image", "눈 건강에 도움", "삼성제약", "야간운전 전 복용 금지", productSeven);
+        ProductInfo productInfoFourteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Lutein", "30 tablets", "Once a day", "Supports vision", "Content image", "Good for eye health", "Samsung chemist", "Avoid before night driving", productSeven);
+        ProductInfo productInfoFifteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "칼슘제", "40 정", "식후 복용", "우유와 함께 복용 권장", "Content image", "뼈 건강에 도움", "삼성제약", "비타민D와 함께 섭취 권장", productEight);
+        ProductInfo productInfoSixteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Calcium", "40 tablets", "After meal", "Recommended with milk", "Content image", "Supports bone health", "Samsung chemist", "Take with vitamin D", productEight);
+
+        List<ProductInfo> productInfoList = Arrays.asList(productInfoOne, productInfoTwo, productInfoThree, productInfoFour, productInfoFive, productInfoSix, productInfoSeven, productInfoEight, productInfoNine, productInfoTen, productInfoEleven, productInfoTwelve, productInfoThirteen, productInfoFourteen, productInfoFifteen, productInfoSixteen);
+
+        List<BestProduct> bestProducts = bestProductList.stream()
+                        .map(product -> BestProduct.of(SnowflakeUtil.nextId(), product))
+                        .toList();
+
+        categoryRepository.saveAll(categoryList);
+        categoryInfoRepository.saveAll(categoryInfoList);
+        productRepository.saveAll(productList);
+        productRepository.flush();
+        productInfoRepository.saveAll(productInfoList);
+        bestProductRepository.saveAll(bestProducts);
+
+        Long categoryId = categoryOne.getId();
+        Long lastProductId = null;
+        int size = 3;
+        Locale locale = Locale.KOREA;
+
+        //when
+        CustomPageResponse<ProductListResponse> result = productService.loadAllProducts(categoryId, lastProductId, size, locale);
+
+        //then
+        assertThat(result.products()).hasSize(size);
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[모든 상품 조회] Locale 이 영어일 경우 모든 상품 정보는 영어로 출력된다.")
+    void loadAllProducts_2() {
+        //given
+        clearDB();
+
+        Category categoryOne = Category.of(SnowflakeUtil.nextId(), "www.category_firstThumbnail.com", "www.category_firstBanner.com");
+        Category categoryTwo = Category.of(SnowflakeUtil.nextId(), "www.category_secondThumbnail.com", "www.category_secondBanner.com");
+        List<Category> categoryList = Arrays.asList(categoryOne, categoryTwo);
+
+        CategoryInfo categoryInfoOne = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민", "비타민은 몸에 좋아요",  categoryOne);
+        CategoryInfo categoryInfoTwo = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "vitamin", "vitamin is necessary for health",  categoryOne);
+        CategoryInfo categoryInfoThree = CategoryInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분", "몸이 튼튼해져요", categoryTwo);
+        CategoryInfo categoryInfoFour = CategoryInfo.of(SnowflakeUtil.nextId(), Language.EN, "Iron", "Helps strengthen the body", categoryTwo);
+        List<CategoryInfo> categoryInfoList = Arrays.asList(categoryInfoOne, categoryInfoTwo, categoryInfoThree, categoryInfoFour);
+
+        Product productOne = Product.of(SnowflakeUtil.nextId(), 25000, 300, "www.product_firstThumbnail.com", categoryOne);
+        Product productTwo = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryOne);
+        Product productThree = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryOne);
+        Product productFour = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryOne);
+        Product productFive = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+        Product productSix = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+        Product productSeven = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+        Product productEight = Product.of(SnowflakeUtil.nextId(), 8000, 12, "www.product_secondThumbnail.com", categoryTwo);
+
+        List<Product> productList = Arrays.asList(productOne, productTwo, productThree, productFour, productFive, productSix, productSeven, productEight);
+        List<Product> bestProductList = Arrays.asList(productOne, productTwo, productFive);
+
+        ProductInfo productInfoOne = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 C", "30 캡슐", "밥과 함께 드시오", "물과 함께 섭취하시오. 하루에 3개.", "Content image", "매우 강력한 마법의 알약", "삼성제약", "오줌이 노래져요", productOne);
+        ProductInfo productInfoTwo = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin C", "30 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productOne);
+        ProductInfo productInfoThree = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 K", "10 캡슐", "밥과 함께 3알 드세요", "과대 섭취 금지", "Content image", "매우 화려한 알약", "삼성제약", "이건 어디 좋은지 몰라요 저희도", productTwo);
+        ProductInfo productInfoFour = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin K", "10 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productTwo);
+        ProductInfo productInfoFive = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 K", "10 캡슐", "밥과 함께 3알 드세요", "과대 섭취 금지", "Content image", "매우 화려한 알약", "삼성제약", "이건 어디 좋은지 몰라요 저희도", productThree);
+        ProductInfo productInfoSix = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin K", "10 capsules", "Take with meal", "Please take 3 capsules daily", "Content image", "Magic pill", "Samsung chemist", "it can make your pee yellow", productThree);
+        ProductInfo productInfoSeven = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "비타민 D", "15 캡슐", "하루에 한 알", "햇빛 대신 섭취하세요", "Content image", "뼈에 좋아요", "삼성제약", "과다 복용 금지", productFour);
+        ProductInfo productInfoEight = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Vitamin D", "15 capsules", "Once a day", "Take as sunlight replacement", "Content image", "Good for bones", "Samsung chemist", "Do not overdose", productFour);
+        ProductInfo productInfoNine = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "철분제", "60 정", "식후 복용", "변비 유발 주의", "Content image", "빈혈에 도움", "삼성제약", "과다 복용 금지", productFive);
+        ProductInfo productInfoTen = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Iron Pill", "60 tablets", "After meal", "May cause constipation", "Content image", "Helps with anemia", "Samsung chemist", "Do not overdose", productFive);
+        ProductInfo productInfoEleven = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "오메가3", "90 정", "식후 복용", "기름기 많음", "Content image", "혈관 건강에 도움", "삼성제약", "임산부는 복용 전 의사 상담", productSix);
+        ProductInfo productInfoTwelve = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Omega-3", "90 tablets", "After meal", "High in fat", "Content image", "Supports heart health", "Samsung chemist", "Consult doctor if pregnant", productSix);
+        ProductInfo productInfoThirteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "루테인", "30 정", "하루 한 알", "눈에 도움", "Content image", "눈 건강에 도움", "삼성제약", "야간운전 전 복용 금지", productSeven);
+        ProductInfo productInfoFourteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Lutein", "30 tablets", "Once a day", "Supports vision", "Content image", "Good for eye health", "Samsung chemist", "Avoid before night driving", productSeven);
+        ProductInfo productInfoFifteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.KO, "칼슘제", "40 정", "식후 복용", "우유와 함께 복용 권장", "Content image", "뼈 건강에 도움", "삼성제약", "비타민D와 함께 섭취 권장", productEight);
+        ProductInfo productInfoSixteen = ProductInfo.of(SnowflakeUtil.nextId(), Language.EN, "Calcium", "40 tablets", "After meal", "Recommended with milk", "Content image", "Supports bone health", "Samsung chemist", "Take with vitamin D", productEight);
+
+        List<ProductInfo> productInfoList = Arrays.asList(productInfoOne, productInfoTwo, productInfoThree, productInfoFour, productInfoFive, productInfoSix, productInfoSeven, productInfoEight, productInfoNine, productInfoTen, productInfoEleven, productInfoTwelve, productInfoThirteen, productInfoFourteen, productInfoFifteen, productInfoSixteen);
+
+        List<BestProduct> bestProducts = bestProductList.stream()
+                .map(product -> BestProduct.of(SnowflakeUtil.nextId(), product))
+                .toList();
+
+        categoryRepository.saveAll(categoryList);
+        categoryInfoRepository.saveAll(categoryInfoList);
+        productRepository.saveAll(productList);
+        productRepository.flush();
+        productInfoRepository.saveAll(productInfoList);
+        bestProductRepository.saveAll(bestProducts);
+
+        Long categoryId = categoryOne.getId();
+        Long lastProductId = null;
+        int size = 3;
+        Locale locale = Locale.ENGLISH;
+
+        //when
+        CustomPageResponse<ProductListResponse> result = productService.loadAllProducts(categoryId, lastProductId, size, locale);
+
+        //then
+        assertThat(result.products())
+                .extracting(ProductListResponse::getProductName)
+                .allMatch(name -> isEnglish(name));
+    }
+
+    private boolean isEnglish(String text) {
+        return text.chars().allMatch(ch -> (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == ' ');
     }
 }

--- a/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
+++ b/src/test/java/com/happypill/application/service/product/ProductServiceTest.java
@@ -372,10 +372,6 @@ public class ProductServiceTest {
         //then
         assertThat(result.products())
                 .extracting(ProductListResponse::getProductName)
-                .allMatch(name -> isEnglish(name));
-    }
-
-    private boolean isEnglish(String text) {
-        return text.chars().allMatch(ch -> (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == ' ');
+                .anyMatch(name -> name.equalsIgnoreCase(productInfoTwo.getName()));
     }
 }


### PR DESCRIPTION
# 티켓
HP-147

# 설명
1. 기존 [모든 상품 조회] 서비스 로직을 deprecated 처리 후 새로운 서비스 로직 생성
2. ProductListResponse 생성
3. DataInitialiser 에 bestProduct 데이터 추가
4. 커스텀 리포지터리 추가

TODO : ProductServiceTest 전체적으로 리팩토링 필요

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합테스트 및 postman 으로 데이터 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 상품 목록 조회 API에서 카테고리, 언어, 페이지네이션(커서) 기반의 조회 기능이 추가되었습니다.
  * 베스트 상품 여부가 포함된 상품 리스트 응답이 제공됩니다.

* **테스트**
  * 상품 목록 조회의 언어별, 페이지네이션 동작을 검증하는 테스트가 추가되었습니다.

* **기타**
  * 개발 환경에서 베스트 상품 데이터가 자동으로 생성됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->