### PR TITLE
HP-151 유저 리프레시

### DIFF
--- a/src/main/java/com/happypill/api/config/SecurityConfig.java
+++ b/src/main/java/com/happypill/api/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 })
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .sessionManagement(s -> s.sessionCreationPolicy(STATELESS))

--- a/src/main/java/com/happypill/api/config/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/happypill/api/config/auth/jwt/JwtProperties.java
@@ -1,12 +1,34 @@
 package com.happypill.api.config.auth.jwt;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+
+import java.time.Duration;
+import java.util.Arrays;
 
 @ConfigurationProperties("jwt")
 public record JwtProperties(
         String issuer,
         String secretKey,
         Integer accessTokenTTLSeconds,
-        Integer refreshTokenTTLSeconds
+        Integer refreshTokenTTLSeconds,
+        Duration refreshSessionTtl
 ) {
+
+    @PostConstruct
+    @Profile("dev")
+    public void validate() {
+        Arrays.stream(JwtProperties.class.getRecordComponents())
+                .forEach(rc -> {
+                    try {
+                        Object value = rc.getAccessor().invoke(this);
+                        if (value == null) {
+                            throw new IllegalArgumentException("null 설정값: " + rc.getName());
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
 }

--- a/src/main/java/com/happypill/api/config/auth/jwt/JwtService.java
+++ b/src/main/java/com/happypill/api/config/auth/jwt/JwtService.java
@@ -82,7 +82,7 @@ public class JwtService {
     }
 
     public TokenPair rotate(String refreshToken) {
-        DecodedJWT decode = JWT.decode(refreshToken);
+        DecodedJWT decode = decode(refreshToken);
         long userId = Long.parseLong(decode.getSubject());
         String secret = decode.getClaim(REFRESH_TOKEN_SECRET).asString();
 
@@ -94,7 +94,7 @@ public class JwtService {
         }
 
         // 만료됬을경우 이전 세션을 지우고, 새로운 토큰을 생성한 후 다시 저장.
-        roles = refreshRepository.getUserInfoAndDelete(userId, secret).orElseThrow(() -> new RuntimeException("세션 정보가 존재하지 않습니다"));
+        roles = refreshRepository.getUserInfoAndDelete(userId, secret).orElseThrow(() -> new RuntimeException("세션 정보가 존재하지 않습니다."));
         return new TokenPair(
                 issueAccessToken(userId, roles),
                 issueRefreshToken(userId, roles)

--- a/src/main/java/com/happypill/api/config/auth/jwt/JwtService.java
+++ b/src/main/java/com/happypill/api/config/auth/jwt/JwtService.java
@@ -4,9 +4,11 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Component
 public class JwtService {
@@ -15,13 +17,21 @@ public class JwtService {
     private final Algorithm algorithm;
     private final JWTVerifier jwtVerifier;
 
-    public JwtService(JwtProperties jwtProperties) {
+    private static final String REFRESH_TOKEN_SECRET = "secret";
+    private final HappypillUserRepository userRepository;
+    private final RefreshSessionRepository refreshRepository;
+
+
+    public JwtService(JwtProperties jwtProperties, RefreshSessionRepository refreshRepository, HappypillUserRepository userRepository) {
         this.jwtProperties = jwtProperties;
         this.algorithm = Algorithm.HMAC256(jwtProperties.secretKey());
         this.jwtVerifier = JWT.require(algorithm).withIssuer(jwtProperties.issuer()).build();
+
+        this.refreshRepository = refreshRepository;
+        this.userRepository = userRepository;
     }
 
-    public String generateAccessToken(Long id, String[] roles) {
+    public String issueAccessToken(Long id, String[] roles) {
         return JWT.create()
                 .withSubject(String.valueOf(id))
                 .withIssuer(jwtProperties.issuer())
@@ -31,12 +41,76 @@ public class JwtService {
                 .sign(algorithm);
     }
 
-    public DecodedJWT parse(String token) {
-        return jwtVerifier.verify(token);
+    public String issueRefreshToken(Long id, String[] roles) {
+        String secret = UUID.randomUUID().toString();
+        String refreshToken = JWT.create()
+                .withIssuer(jwtProperties.issuer())
+                .withSubject(String.valueOf(id))
+                .withIssuedAt(Instant.now())
+                .withClaim(REFRESH_TOKEN_SECRET, secret)
+                .withExpiresAt(calculateExpiration(jwtProperties.refreshTokenTTLSeconds()))
+                .sign(algorithm);
+
+        refreshRepository.save(id, secret, roles, jwtProperties.refreshSessionTtl());
+        return refreshToken;
     }
+
 
     private Instant calculateExpiration(long ttlSeconds) {
         return Instant.now().plusSeconds(ttlSeconds);
+    }
+
+
+    /**
+     * accessToken 검증시에만 사용
+     *
+     * @param accessToken accessToken
+     * @return {@link DecodedJWT}
+     */
+    public DecodedJWT verifyAndDecode(String accessToken) {
+        return jwtVerifier.verify(accessToken);
+    }
+
+    /**
+     * refreshToken 검증시에만 사용
+     *
+     * @param refreshToken
+     * @return {@link DecodedJWT}
+     */
+    private DecodedJWT decode(String refreshToken) {
+        return JWT.decode(refreshToken);
+    }
+
+    public TokenPair rotate(String refreshToken) {
+        DecodedJWT decode = JWT.decode(refreshToken);
+        long userId = Long.parseLong(decode.getSubject());
+        String secret = decode.getClaim(REFRESH_TOKEN_SECRET).asString();
+
+        String[] roles;
+
+        if (decode.getExpiresAtAsInstant().isAfter(Instant.now())) {
+            roles = refreshRepository.getUserInfo(userId, secret).orElseThrow(() -> new RuntimeException("세션 정보가 존재하지 않습니다."));
+            return new TokenPair(issueAccessToken(userId, roles), null);
+        }
+
+        // 만료됬을경우 이전 세션을 지우고, 새로운 토큰을 생성한 후 다시 저장.
+        roles = refreshRepository.getUserInfoAndDelete(userId, secret).orElseThrow(() -> new RuntimeException("세션 정보가 존재하지 않습니다"));
+        return new TokenPair(
+                issueAccessToken(userId, roles),
+                issueRefreshToken(userId, roles)
+        );
+    }
+
+    public void delete(String refreshToken) {
+        DecodedJWT decode = JWT.decode(refreshToken);
+        long userId = Long.parseLong(decode.getSubject());
+        String secret = decode.getClaim(REFRESH_TOKEN_SECRET).asString();
+
+        refreshRepository.delete(userId, secret);
+    }
+
+
+    public record TokenPair(String accessToken, String refreshToken) {
     }
 
 }

--- a/src/main/java/com/happypill/api/config/auth/jwt/RefreshSessionRepository.java
+++ b/src/main/java/com/happypill/api/config/auth/jwt/RefreshSessionRepository.java
@@ -1,0 +1,65 @@
+package com.happypill.api.config.auth.jwt;
+
+import com.happypill.application.util.DataSerializerUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class RefreshSessionRepository {
+    private static final String KEY_PATTERN = "refresh:{%d}:%s";
+    private final StringRedisTemplate redisTemplate;
+
+    private String generateKey(long userId, String uuid) {
+        return String.format(KEY_PATTERN, userId, uuid);
+    }
+
+    public Optional<String[]> getUserInfo(long userId, String uuid) {
+        String raw = redisTemplate.opsForValue()
+                .get(generateKey(userId, uuid));
+        try {
+            return Optional.of(DataSerializerUtil.deserialize(raw, String[].class));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+
+    public void save(long userId, String uuid, String[] roles, Duration ttl) {
+        String raw = DataSerializerUtil.serialize(roles);
+        redisTemplate.opsForValue()
+                .set(generateKey(userId, uuid), raw, ttl);
+    }
+
+    /**
+     * 로그아웃시 사용
+     */
+    public boolean delete(long userId, String uuid) {
+        return redisTemplate.delete(generateKey(userId, uuid));
+    }
+
+    /**
+     * 로테이션시 사용
+     */
+    public Optional<String[]> getUserInfoAndDelete(long userId, String uuid) {
+        String raw = redisTemplate.opsForValue()
+                .getAndDelete(generateKey(userId, uuid));
+        try {
+            return Optional.of(DataSerializerUtil.deserialize(raw, String[].class));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+//    해킹당했을때
+//    public void revokeAll(){
+//
+//    }
+
+}

--- a/src/main/java/com/happypill/api/config/auth/jwt/RefreshSessionRepository.java
+++ b/src/main/java/com/happypill/api/config/auth/jwt/RefreshSessionRepository.java
@@ -20,9 +20,9 @@ public class RefreshSessionRepository {
         return String.format(KEY_PATTERN, userId, uuid);
     }
 
-    public Optional<String[]> getUserInfo(long userId, String uuid) {
+    public Optional<String[]> getUserInfo(long userId, String secret) {
         String raw = redisTemplate.opsForValue()
-                .get(generateKey(userId, uuid));
+                .get(generateKey(userId, secret));
         try {
             return Optional.of(DataSerializerUtil.deserialize(raw, String[].class));
         } catch (RuntimeException e) {
@@ -31,25 +31,25 @@ public class RefreshSessionRepository {
     }
 
 
-    public void save(long userId, String uuid, String[] roles, Duration ttl) {
+    public void save(long userId, String secret, String[] roles, Duration ttl) {
         String raw = DataSerializerUtil.serialize(roles);
         redisTemplate.opsForValue()
-                .set(generateKey(userId, uuid), raw, ttl);
+                .set(generateKey(userId, secret), raw, ttl);
     }
 
     /**
      * 로그아웃시 사용
      */
-    public boolean delete(long userId, String uuid) {
-        return redisTemplate.delete(generateKey(userId, uuid));
+    public boolean delete(long userId, String secret) {
+        return redisTemplate.delete(generateKey(userId, secret));
     }
 
     /**
      * 로테이션시 사용
      */
-    public Optional<String[]> getUserInfoAndDelete(long userId, String uuid) {
+    public Optional<String[]> getUserInfoAndDelete(long userId, String secret) {
         String raw = redisTemplate.opsForValue()
-                .getAndDelete(generateKey(userId, uuid));
+                .getAndDelete(generateKey(userId, secret));
         try {
             return Optional.of(DataSerializerUtil.deserialize(raw, String[].class));
         } catch (RuntimeException e) {

--- a/src/main/java/com/happypill/api/config/auth/jwt/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/happypill/api/config/auth/jwt/security/JwtAuthenticationProvider.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         try {
 
             String accessToken = (String) authentication.getCredentials();
-            DecodedJWT parsedJwt = jwtService.parse(accessToken);
+            DecodedJWT parsedJwt = jwtService.verifyAndDecode(accessToken);
 
             String subject = parsedJwt.getSubject();
             Long userId = Long.valueOf(subject);

--- a/src/main/java/com/happypill/api/config/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/happypill/api/config/auth/oauth2/OAuth2SuccessHandler.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -22,8 +21,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         OAuth2UserPrincipal principal = (OAuth2UserPrincipal) authentication.getPrincipal();
 
-        String accessToken = jwtService.generateAccessToken(principal.getId(), principal.getRoleNames());
-        String refreshToken = UUID.randomUUID().toString();
+        String accessToken = jwtService.issueAccessToken(principal.getId(), principal.getRoleNames());
+        String refreshToken = jwtService.issueRefreshToken(principal.getId(), principal.getRoleNames());
 
         //TODO refreshToken 전략
         String redirectUrl = UriComponentsBuilder

--- a/src/main/java/com/happypill/api/config/filter/DebugFilterInspector.java
+++ b/src/main/java/com/happypill/api/config/filter/DebugFilterInspector.java
@@ -1,0 +1,53 @@
+package com.happypill.api.config.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.ServletContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * 테스트 목적으로 사용할 컴포넌트
+ * 개발기간 끝나면 제거 예정
+ */
+@Profile("dev")
+@Component
+@RequiredArgsConstructor
+public class DebugFilterInspector implements ApplicationRunner {
+    private final ServletContext servletContext;
+    private final FilterChainProxy springSecurityFilterChain;
+
+
+    @Override
+    public void run(ApplicationArguments args) {
+        printServletFilters();
+        printSpringSecurityFilters();
+    }
+
+    private void printServletFilters() {
+        System.out.println("=== [ServletContext Filters] ===");
+        Map<String, ? extends FilterRegistration> filters = servletContext.getFilterRegistrations();
+        filters.forEach((name, registration) -> {
+            System.out.printf("Filter Name: %s%n", name);
+            System.out.printf("Class Name: %s%n", registration.getClassName());
+            System.out.println("---------------------------------");
+        });
+    }
+
+    private void printSpringSecurityFilters() {
+        System.out.println("=== [Spring Security FilterChainProxy Filters] ===");
+        for (SecurityFilterChain chain : springSecurityFilterChain.getFilterChains()) {
+            for (Filter filter : chain.getFilters()) {
+                System.out.println(" - " + filter.getClass().getName());
+            }
+            System.out.println("---------------------------------");
+        }
+    }
+}

--- a/src/main/java/com/happypill/api/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/happypill/api/config/filter/JwtAuthenticationFilter.java
@@ -19,6 +19,8 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 @Slf4j
 public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
+    private static final String BEARER_PREFIX = "Bearer ";
+
     public JwtAuthenticationFilter(AuthenticationManager authenticationManager) {
         super(request -> true); // requiresAuthentication을 오버라이드하면 동작하지 않는다. 그냥 생성자때문에 넣어놓는것.
         setAuthenticationManager(authenticationManager);
@@ -27,13 +29,13 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
     @Override // 상위 구현체에서, 생성자의 RequestMatcher를 사용하기 때문에, 커스텀하게 오버라이드하는 순간 동작하지 않는다.
     protected boolean requiresAuthentication(HttpServletRequest request, HttpServletResponse response) {
         String bearerHeader = request.getHeader(AUTHORIZATION);
-        return bearerHeader != null && bearerHeader.startsWith("Bearer ");
+        return bearerHeader != null && bearerHeader.startsWith(BEARER_PREFIX);
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
         log.info("attemptAuthentication - URI: {} | Thread: {}", request.getRequestURI(), Thread.currentThread().getName());
-        String accessToken = request.getHeader(AUTHORIZATION).substring(7);
+        String accessToken = request.getHeader(AUTHORIZATION).substring(BEARER_PREFIX.length());
         JwtAuthenticationToken jwtAuthenticationToken = JwtAuthenticationToken.unAuthenticated(accessToken);
         return getAuthenticationManager().authenticate(jwtAuthenticationToken);
     }

--- a/src/main/java/com/happypill/api/config/filter/JwtLogoutFilter.java
+++ b/src/main/java/com/happypill/api/config/filter/JwtLogoutFilter.java
@@ -1,0 +1,41 @@
+package com.happypill.api.config.filter;
+
+import com.happypill.api.config.auth.jwt.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtLogoutFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final JwtService jwtService;
+    private final RequestMatcher matcher = new AntPathRequestMatcher("/auth/logout", "POST");
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return !matcher.matches(request);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            ServletResponseUtils.sendErrorResponse(response, HttpStatus.BAD_REQUEST, "Authorization header missing or invalid");
+            return;
+        }
+
+        String refreshToken = header.substring(BEARER_PREFIX.length());
+
+        jwtService.delete(refreshToken);
+    }
+}

--- a/src/main/java/com/happypill/api/config/filter/JwtRotateFilter.java
+++ b/src/main/java/com/happypill/api/config/filter/JwtRotateFilter.java
@@ -1,0 +1,51 @@
+package com.happypill.api.config.filter;
+
+import com.happypill.api.config.auth.jwt.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtRotateFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final JwtService jwtService;
+    private final RequestMatcher matcher = new AntPathRequestMatcher("/auth/refresh", "POST");
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return !matcher.matches(request);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            ServletResponseUtils.sendErrorResponse(response, HttpStatus.BAD_REQUEST, "Authorization header missing or invalid");
+            return;
+        }
+
+        String refreshToken = header.substring(BEARER_PREFIX.length());
+
+        try {
+            JwtService.TokenPair tokenPair = jwtService.rotate(refreshToken);
+            ServletResponseUtils.sendSuccessResponse(response, tokenPair);
+        } catch (RuntimeException e) {
+            log.error("refresh rotate failed", e);
+            ServletResponseUtils.sendErrorResponse(response, HttpStatus.BAD_REQUEST, "Token rotate failed");
+        }
+    }
+
+}

--- a/src/main/java/com/happypill/api/config/filter/SecurityFilterDsl.java
+++ b/src/main/java/com/happypill/api/config/filter/SecurityFilterDsl.java
@@ -1,5 +1,6 @@
 package com.happypill.api.config.filter;
 
+import com.happypill.api.config.auth.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,16 +12,22 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SecurityFilterDsl extends AbstractHttpConfigurer<SecurityFilterDsl, HttpSecurity> {
 
+    private final JwtService jwtService;
+
     @Override
     public void configure(HttpSecurity builder) {
         AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
-        JwtAuthenticationFilter jwtAuthenticationFilter = jwtAuthenticationFilter(authenticationManager);
 
-        builder.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        JwtLogoutFilter jwtLogoutFilter = new JwtLogoutFilter(jwtService);
+        builder.addFilterBefore(jwtLogoutFilter, UsernamePasswordAuthenticationFilter.class);
+
+        JwtRotateFilter jwtRotateFilter = new JwtRotateFilter(jwtService);
+        builder.addFilterAfter(jwtRotateFilter, JwtLogoutFilter.class);
+
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager);
+        builder.addFilterAfter(jwtAuthenticationFilter, JwtRotateFilter.class);
+
+
     }
 
-    private JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationManager authenticationManager) {
-        return new JwtAuthenticationFilter(authenticationManager);
-    }
-    
 }

--- a/src/main/java/com/happypill/api/config/filter/ServletResponseUtils.java
+++ b/src/main/java/com/happypill/api/config/filter/ServletResponseUtils.java
@@ -1,0 +1,33 @@
+package com.happypill.api.config.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ServletResponseUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static <T> void sendSuccessResponse(HttpServletResponse response, T data) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        objectMapper.writeValue(response.getWriter(), data);
+    }
+
+    public static void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(message);
+    }
+
+}

--- a/src/main/java/com/happypill/api/controller/test/TestController.java
+++ b/src/main/java/com/happypill/api/controller/test/TestController.java
@@ -31,7 +31,7 @@ public class TestController {
 
     @GetMapping("/testToken")
     public String getTestToken() {
-        return jwtService.generateAccessToken(1L, new String[]{"USER", "ADMIN"});
+        return jwtService.issueAccessToken(1L, new String[]{"USER", "ADMIN"});
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,8 @@ spring:
 jwt:
   access-token-ttlSeconds: 6000
   refresh-token-ttlSeconds: 86400 # 60 * 60 * 24
+  refresh-session-ttl: 10h
+  refresh-session-long-ttl: 180d
   secret-key: ${JWT_SECRET_KEY:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2W3x4Y5z6A7B8C9D0E1F2G3H4I5J6K7L8M9N0O1P2Q3R4S5T6U7V8W9X0Y1Z2a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8A9B0C1D2E3F4G5H6}
   issuer: https://happypill-api.jiheon2234.dev
 

--- a/src/test/java/com/happypill/api/config/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/happypill/api/config/auth/jwt/JwtServiceTest.java
@@ -190,8 +190,7 @@ class JwtServiceTest extends IntegrationTestSupport {
 
         // when & then
         assertThatThrownBy(() -> jwtService.rotate(refreshToken))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("세션 정보가 존재하지 않습니다");
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test
@@ -205,15 +204,10 @@ class JwtServiceTest extends IntegrationTestSupport {
         String refreshToken = jwtService.issueRefreshToken(userId, roles);
         DecodedJWT decoded = jwtService.verifyAndDecode(refreshToken);
         String secret = decoded.getClaim("secret").asString();
+        refreshSessionRepository.delete(userId, secret);
 
-        // Redis에서 해당 세션 수동 삭제 (실제로는 RefreshSessionRepository 주입 필요)
-        // 여기서는 존재하지 않는 userId를 사용하여 세션이 없는 상황 시뮬레이션
-
-        // when & then
-        // 현재 구현상 세션이 존재하므로 정상 동작할 것임
-        // 실제 테스트에서는 RefreshSessionRepository를 Autowired하여 직접 삭제해야 함
-        JwtService.TokenPair result = jwtService.rotate(refreshToken);
-        assertThat(result.accessToken()).isNotNull();
+        assertThatThrownBy(() -> jwtService.rotate(refreshToken))
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test

--- a/src/test/java/com/happypill/api/config/auth/jwt/JwtServiceTest.java
+++ b/src/test/java/com/happypill/api/config/auth/jwt/JwtServiceTest.java
@@ -1,0 +1,235 @@
+package com.happypill.api.config.auth.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.happypill.application.service.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @Autowired
+    private RefreshSessionRepository refreshSessionRepository;
+
+    @Test
+    @DisplayName("액세스 토큰을 성공적으로 발급한다")
+    void issueAccessToken_Success() {
+        // given
+        Long userId = 1L;
+        String[] roles = {"USER", "ADMIN"};
+
+        // when
+        String accessToken = jwtService.issueAccessToken(userId, roles);
+
+        // then
+        DecodedJWT decoded = jwtService.verifyAndDecode(accessToken);
+        assertThat(decoded.getSubject()).isEqualTo(String.valueOf(userId));
+        assertThat(decoded.getIssuer()).isEqualTo(jwtProperties.issuer());
+        assertThat(decoded.getClaim("roles").asArray(String.class)).containsExactly(roles);
+        assertThat(decoded.getExpiresAtAsInstant()).isAfter(Instant.now());
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰을 성공적으로 발급한다- REDIS에 유저정보가 저장되어 있다")
+    void issueRefreshToken_Success() {
+        // given
+        Long userId = 1L;
+        String[] roles = {"USER"};
+
+        // when
+        String refreshToken = jwtService.issueRefreshToken(userId, roles);
+
+        // then
+        assertThat(refreshToken).isNotNull();
+        assertThat(refreshToken).isNotEmpty();
+
+        DecodedJWT decoded = jwtService.verifyAndDecode(refreshToken);
+        assertThat(decoded.getSubject()).isEqualTo(String.valueOf(userId));
+        assertThat(decoded.getIssuer()).isEqualTo(jwtProperties.issuer());
+        assertThat(decoded.getClaim("secret").asString()).isNotNull();
+        assertThat(decoded.getExpiresAtAsInstant()).isAfter(Instant.now());
+        assertThat(refreshSessionRepository.getUserInfo(userId, decoded.getClaim("secret").asString())).isPresent();
+    }
+
+
+    @Test
+    @DisplayName("만료되지 않은 리프레시 토큰으로 액세스 토큰만 로테이션한다")
+    void rotate_ValidRefreshToken_ReturnsAccessTokenOnly() {
+        // given
+        Long userId = 1L;
+        String[] roles = {"USER", "ADMIN"};
+        String refreshToken = jwtService.issueRefreshToken(userId, roles);
+
+        // when
+        JwtService.TokenPair tokenPair = jwtService.rotate(refreshToken);
+
+        // then
+        assertThat(tokenPair.accessToken()).isNotNull();
+        assertThat(tokenPair.refreshToken()).isNull();
+
+        DecodedJWT newAccessToken = jwtService.verifyAndDecode(tokenPair.accessToken());
+        assertThat(newAccessToken.getSubject()).isEqualTo(String.valueOf(userId));
+        assertThat(newAccessToken.getClaim("roles").asArray(String.class)).containsExactly(roles);
+    }
+
+
+    @Test
+    @DisplayName("리프레시 토큰 로테이션 - 연속 호출 시 새로운 액세스 토큰 발급")
+    void rotate_ConsecutiveCalls_IssuesNewAccessTokens() throws Exception {
+        // given
+        Long userId = 1L;
+        String[] roles = {"USER", "ADMIN"};
+        String refreshToken = jwtService.issueRefreshToken(userId, roles);
+
+        // when - 첫 번째 로테이션
+        JwtService.TokenPair firstRotation = jwtService.rotate(refreshToken);
+
+        // then - 첫 번째 로테이션 검증
+        assertThat(firstRotation.accessToken()).isNotNull();
+        assertThat(firstRotation.refreshToken()).isNull(); // 만료되지 않았으므로 null
+
+
+        Thread.sleep(1000); // 같은 시간에 생성될때가 있어 1초 대기
+
+        // when - 두 번째 로테이션 (같은 리프레시 토큰 사용)
+        JwtService.TokenPair secondRotation = jwtService.rotate(refreshToken);
+
+        // then - 두 번째 로테이션 검증
+        assertThat(secondRotation.accessToken()).isNotNull();
+        assertThat(secondRotation.refreshToken()).isNull();
+
+        // 디버깅을 위해 토큰 발급 시간 확인
+        DecodedJWT firstDecoded = jwtService.verifyAndDecode(firstRotation.accessToken());
+        DecodedJWT secondDecoded = jwtService.verifyAndDecode(secondRotation.accessToken());
+        // 두 액세스 토큰은 달라야 함
+        assertThat(firstRotation.accessToken()).isNotEqualTo(secondRotation.accessToken());
+
+        // 두 토큰 모두 유효해야 함
+        assertThat(firstDecoded.getSubject()).isEqualTo(String.valueOf(userId));
+        assertThat(secondDecoded.getSubject()).isEqualTo(String.valueOf(userId));
+        assertThat(firstDecoded.getClaim("roles").asArray(String.class)).containsExactly(roles);
+        assertThat(secondDecoded.getClaim("roles").asArray(String.class)).containsExactly(roles);
+    }
+
+    @Test
+    @DisplayName("만료된 리프레시 토큰 로테이션 - 새로운 토큰 쌍 생성")
+    void rotate_ExpiredRefreshToken_CreatesNewTokenPair() {
+        // given
+        Long userId = 1L;
+        String[] roles = {"USER"};
+        String secret = "test-secret-uuid";
+
+        // 만료된 리프레시 토큰을 수동으로 생성
+        String expiredRefreshToken = JWT.create()
+                .withSubject(String.valueOf(userId))
+                .withIssuer(jwtProperties.issuer())
+                .withIssuedAt(Instant.now().minusSeconds(10))
+                .withExpiresAt(Instant.now().minusSeconds(1)) // 1초 전에 만료
+                .withClaim("secret", secret)
+                .sign(Algorithm.HMAC256(jwtProperties.secretKey()));
+
+        // Redis에 세션 정보 저장 (만료된 토큰이지만 세션은 아직 존재)
+        refreshSessionRepository.save(userId, secret, roles, jwtProperties.refreshSessionTtl());
+
+        // when
+        JwtService.TokenPair tokenPair = jwtService.rotate(expiredRefreshToken);
+
+        // then - 만료된 토큰이므로 새로운 토큰 쌍이 생성되어야 함
+        assertThat(tokenPair.accessToken()).isNotNull();
+        assertThat(tokenPair.refreshToken()).isNotNull(); // 만료되었으므로 새 리프레시 토큰 생성
+
+        // 새로운 액세스 토큰 검증
+        DecodedJWT newAccessToken = jwtService.verifyAndDecode(tokenPair.accessToken());
+        assertThat(newAccessToken.getSubject()).isEqualTo(String.valueOf(userId));
+        assertThat(newAccessToken.getClaim("roles").asArray(String.class)).containsExactly(roles);
+
+        // 새로운 리프레시 토큰 검증
+        DecodedJWT newRefreshToken = jwtService.verifyAndDecode(tokenPair.refreshToken());
+        assertThat(newRefreshToken.getSubject()).isEqualTo(String.valueOf(userId));
+        assertThat(newRefreshToken.getClaim("secret").asString()).isNotNull();
+        assertThat(newRefreshToken.getClaim("secret").asString()).isNotEqualTo(secret); // 새로운 secret
+        assertThat(newRefreshToken.getExpiresAtAsInstant()).isAfter(Instant.now()); // 새로운 만료 시간
+
+        // 기존 세션은 삭제되고 새로운 세션이 생성되었는지 확인
+        assertThat(refreshSessionRepository.getUserInfo(userId, secret)).isEmpty();
+
+        // 새로운 세션이 생성되었는지 확인
+        String newSecret = newRefreshToken.getClaim("secret").asString();
+        assertThat(refreshSessionRepository.getUserInfo(userId, newSecret)).isPresent();
+    }
+
+
+    @Test
+    @DisplayName("세션이 수동으로 삭제된 후 로테이션 시 예외 발생")
+    void rotate_SessionManuallyDeleted_ThrowsException() {
+        // given
+        Long userId = 1L;
+        String[] roles = {"USER"};
+        String refreshToken = jwtService.issueRefreshToken(userId, roles);
+
+        // 세션 정보 추출
+        DecodedJWT decoded = jwtService.verifyAndDecode(refreshToken);
+        String secret = decoded.getClaim("secret").asString();
+
+        // 세션을 수동으로 삭제
+        boolean deleted = refreshSessionRepository.delete(userId, secret);
+        assertThat(deleted).isTrue(); // 삭제 성공 확인
+
+        // when & then
+        assertThatThrownBy(() -> jwtService.rotate(refreshToken))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("세션 정보가 존재하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션으로 로테이션시 예외가 발생한다")
+    void rotate_NonExistentSession_ThrowsException() {
+        // given - 유효한 형식이지만 존재하지 않는 secret을 가진 토큰 생성
+        Long userId = 999L;
+        String[] roles = {"USER"};
+
+        // 임시로 토큰을 생성한 후 세션을 수동으로 삭제하여 존재하지 않는 상태 만들기
+        String refreshToken = jwtService.issueRefreshToken(userId, roles);
+        DecodedJWT decoded = jwtService.verifyAndDecode(refreshToken);
+        String secret = decoded.getClaim("secret").asString();
+
+        // Redis에서 해당 세션 수동 삭제 (실제로는 RefreshSessionRepository 주입 필요)
+        // 여기서는 존재하지 않는 userId를 사용하여 세션이 없는 상황 시뮬레이션
+
+        // when & then
+        // 현재 구현상 세션이 존재하므로 정상 동작할 것임
+        // 실제 테스트에서는 RefreshSessionRepository를 Autowired하여 직접 삭제해야 함
+        JwtService.TokenPair result = jwtService.rotate(refreshToken);
+        assertThat(result.accessToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("토큰에 여러 역할이 포함될 때 올바르게 처리한다")
+    void issueAndVerifyToken_WithMultipleRoles_Success() {
+        // given
+        Long userId = 1L;
+        String[] roles = {"USER", "ADMIN", "MANAGER"};
+
+        // when
+        String accessToken = jwtService.issueAccessToken(userId, roles);
+        DecodedJWT decoded = jwtService.verifyAndDecode(accessToken);
+
+        // then
+        assertThat(decoded.getClaim("roles").asArray(String.class))
+                .containsExactlyInAnyOrder(roles);
+    }
+
+}

--- a/src/test/java/com/happypill/application/service/IntegrationTestSupport.java
+++ b/src/test/java/com/happypill/application/service/IntegrationTestSupport.java
@@ -1,19 +1,26 @@
 package com.happypill.application.service;
 
 import com.happypill.application.client.EmailSender;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
+@SpringBootTest
 public abstract class IntegrationTestSupport {
 
-    @Container
+    //
     protected static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:8")
-            .withExposedPorts(6379);
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    static {
+        redisContainer.start();
+    }
+
 
     @DynamicPropertySource
     static void configureRedisProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/happypill/application/service/user/UserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/user/UserServiceTest.java
@@ -17,7 +17,6 @@ import net.datafaker.Faker;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
@@ -25,7 +24,6 @@ import java.time.Duration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
 @Transactional
 class UserServiceTest extends IntegrationTestSupport {
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -46,11 +46,12 @@ app:
 
 
 jwt:
-  access-token-ttlSeconds: 300 # 60 * 5
-  refresh-token-ttlSeconds: 86400 # 60 * 5
+  access-token-ttlSeconds: 6000
+  refresh-token-ttlSeconds: 86400 # 60 * 60 * 24
+  refresh-session-ttl: 10h
+  refresh-session-long-ttl: 180d
   secret-key: ${JWT_SECRET_KEY:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2W3x4Y5z6A7B8C9D0E1F2G3H4I5J6K7L8M9N0O1P2Q3R4S5T6U7V8W9X0Y1Z2a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8A9B0C1D2E3F4G5H6}
   issuer: https://happypill-api.jiheon2234.dev
-
 portone:
   api-secret: secret
   store-id: store-484


### PR DESCRIPTION
/auth/refresh 경로로 AUTHORIZATION 헤더에 refresh token을 담아 post 요청을 보내면, 새로운 accessToken을 body에 담아 돌려준다.

refresh token이 만료됬다면
- redis에 정보가 남아있는 경우, 이를 1회만 허용하여 회전시키고 응답한다.
- redis에 정보가 없다면 바로 에러처리

/auth/logout 경로로 AUTHORIZATION 헤더에 refresh token을 담아 post 요청을 보내면 redis에서 정보를 삭제한다.

오류는 전부 RuntimeException으로 구현

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
코드와 관련하여 어떻게 테스트하였는지 작성해주세요

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [ ] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 리프레시 토큰 발급, 검증, 회전(로테이션), 삭제 등 전체 라이프사이클 관리 기능이 추가되었습니다.
  * /auth/refresh 엔드포인트에서 리프레시 토큰을 통한 액세스 토큰 재발급이 가능합니다.
  * /auth/logout 엔드포인트에서 리프레시 토큰 무효화(로그아웃)가 지원됩니다.
  * 개발 환경에서 필터 체인 및 서블릿 필터 정보를 출력하는 디버그 도구가 추가되었습니다.
  * JWT 관련 필터 체인이 확장되어 인증, 로그아웃, 토큰 회전 필터가 추가 및 재배치되었습니다.
  * HTTP 응답을 JSON 형식으로 처리하는 유틸리티 기능이 도입되었습니다.

* **버그 수정**
  * JWT 관련 인증 플로우에서 토큰 검증 방식이 강화되었습니다.

* **설정**
  * JWT 리프레시 세션 TTL 관련 설정값이 추가되었습니다(application.yml).

* **테스트**
  * JWT 서비스의 토큰 발급 및 회전 기능에 대한 단위 테스트가 추가되었습니다.
  * 테스트 환경의 Redis 컨테이너 관리 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->