### PR TITLE
HP-156 : CustomPageResponse 내의 Long lastProductId -> String 타입으로 변경

### DIFF
--- a/src/main/java/com/happypill/application/service/product/ProductService.java
+++ b/src/main/java/com/happypill/application/service/product/ProductService.java
@@ -55,7 +55,7 @@ public class ProductService {
                         .map(pi -> ProductResponse.from(pi, getCurrentPrice(pi)))
                         .toList(),
                 hasNext,
-                productInfoList.getLast().getProduct().getId()
+                productInfoList.getLast().getProduct().getId().toString()
         );
 
         return response;
@@ -70,7 +70,7 @@ public class ProductService {
 
         List<ProductListResponse> result = hasNext ? content.subList(0, size) : content;
 
-        Long nextLastProductId = result.isEmpty() ? null : Long.valueOf(result.getLast().getProductId());
+        String nextLastProductId = result.isEmpty() ? null : result.getLast().getProductId();
 
         return new CustomPageResponse<>(result, hasNext, nextLastProductId);
     }

--- a/src/main/java/com/happypill/application/service/product/response/CustomPageResponse.java
+++ b/src/main/java/com/happypill/application/service/product/response/CustomPageResponse.java
@@ -2,4 +2,4 @@ package com.happypill.application.service.product.response;
 
 import java.util.List;
 
-public record CustomPageResponse<T> (List<T> products, boolean hasNext, Long lastProductId){}
+public record CustomPageResponse<T> (List<T> products, boolean hasNext, String lastProductId){}


### PR DESCRIPTION
# 티켓
HP-156

# 설명
- 프론트의 JS에서 SnowFlakeID 를 못 받는 이슈로 CustomPageResponse 의 Long lastProductId 필드를 String 타입으로 변경

## 타입
- [x] 버그
- [ ] 작업
- [ ] 기능 향상

# 테스트 방법
테스트 없음

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 상품 목록 페이지네이션에서 마지막 상품 ID의 데이터 타입이 Long에서 String으로 변경되어, 페이지 이동 시 더 일관된 동작을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->