### PR TITLE
HP-157 : 회원 닉네임 입력 API 구현

### DIFF
--- a/src/main/java/com/happypill/api/controller/UserController.java
+++ b/src/main/java/com/happypill/api/controller/UserController.java
@@ -5,6 +5,7 @@ import com.happypill.application.auth.UserContext;
 import com.happypill.application.exception.global.ErrorResponse;
 import com.happypill.application.service.user.UserService;
 import com.happypill.application.service.user.request.EmailVerificationRequest;
+import com.happypill.application.service.user.request.UserNicknameRegisterRequest;
 import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
 import com.happypill.application.service.user.request.UserUpdateRequest;
 import com.happypill.application.service.user.response.UserInfoResponse;
@@ -62,4 +63,13 @@ public class UserController {
                                            @RequestBody @Valid UserNotifyEmailUpdateRequest request) {
         userService.verifyAndUpdateUserNotifyEmail(userContext, request);
     }
+
+    @Operation(summary = "회원 닉네임 입력 및 등록", description = "회원이 닉네임을 직접 등록하기 위한 API")
+    @PatchMapping("/api/user/me/nickname")
+    @PreAuthorize("hasRole('USER')")
+    public void registerNickname(@HappypillUser UserContext userContext,
+                                 @RequestBody @Valid UserNicknameRegisterRequest userNicknameRegisterRequest) {
+        userService.registerNickname(userContext, userNicknameRegisterRequest);
+    }
+
 }

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -2,6 +2,8 @@ package com.happypill.application.entity;
 
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
+import com.happypill.application.exception.custom.ExceptionCode;
+import com.happypill.application.exception.global.BusinessException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -61,5 +63,12 @@ public class HappypillUser extends BaseEntity<Long> {
 
     public void activate() {
         this.isDeleted = false;
+    }
+
+    public void registerNickName(String nickName) {
+        if(this.nickName != null) {
+            throw new BusinessException(ExceptionCode.USER_NICKNAME_ALREADY_REGISTERED);
+        }
+        this.nickName = nickName;
     }
 }

--- a/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
+++ b/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
@@ -31,7 +31,8 @@ public enum ExceptionCode {
     CATEGORY_INFO_NOT_FOUND(NOT_FOUND, "해당 카테고리 정보를 찾을 수 없습니다"),
 
     USER_ALREADY_DELETED(BAD_REQUEST, "이미 삭제된 회원입니다."),
-    USER_NOT_DELETED(BAD_REQUEST, "삭제되지 않은 회원입니다.");
+    USER_NOT_DELETED(BAD_REQUEST, "삭제되지 않은 회원입니다."),
+    USER_NICKNAME_ALREADY_REGISTERED(BAD_REQUEST, "닉네임이 이미 등록된 회원입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/happypill/application/exception/global/ValidNickname.java
+++ b/src/main/java/com/happypill/application/exception/global/ValidNickname.java
@@ -1,0 +1,15 @@
+package com.happypill.application.exception.global;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidNicknameValidator.class)
+public @interface ValidNickname {
+    String message() default "유효하지 않은 닉네임입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/happypill/application/exception/global/ValidNicknameValidator.java
+++ b/src/main/java/com/happypill/application/exception/global/ValidNicknameValidator.java
@@ -1,0 +1,16 @@
+package com.happypill.application.exception.global;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Set;
+
+public class ValidNicknameValidator implements ConstraintValidator<ValidNickname, String> {
+
+    private static final String FORBIDDEN_WORDS = "null";
+
+    @Override
+    public boolean isValid(String nickName, ConstraintValidatorContext constraintValidatorContext) {
+        return !FORBIDDEN_WORDS.contains(nickName.trim().toLowerCase());
+    }
+}

--- a/src/main/java/com/happypill/application/service/user/UserService.java
+++ b/src/main/java/com/happypill/application/service/user/UserService.java
@@ -8,6 +8,7 @@ import com.happypill.application.exception.global.BusinessException;
 import com.happypill.application.repository.happypilluser.HappypillUserRepository;
 import com.happypill.application.service.user.email.EmailVerificationRedisRepository;
 import com.happypill.application.service.user.request.EmailVerificationRequest;
+import com.happypill.application.service.user.request.UserNicknameRegisterRequest;
 import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
 import com.happypill.application.service.user.request.UserUpdateRequest;
 import com.happypill.application.service.user.response.UserInfoResponse;
@@ -71,6 +72,13 @@ public class UserService {
         HappypillUser user = userRepository.findById(userContext.getId())
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
         user.changeNotifyEmail(request.notifyEmail());
+    }
+
+    @Transactional
+    public void registerNickname(UserContext userContext, UserNicknameRegisterRequest userNicknameRegisterRequest) {
+        HappypillUser user = userRepository.findById(userContext.getId())
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+        user.registerNickName(userNicknameRegisterRequest.nickName());
     }
 
     private void verifyNotifyEmail(UserContext userContext, UserNotifyEmailUpdateRequest request) {

--- a/src/main/java/com/happypill/application/service/user/request/UserNicknameRegisterRequest.java
+++ b/src/main/java/com/happypill/application/service/user/request/UserNicknameRegisterRequest.java
@@ -1,0 +1,11 @@
+package com.happypill.application.service.user.request;
+
+import com.happypill.application.exception.global.ValidNickname;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserNicknameRegisterRequest(
+        @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
+        @ValidNickname
+        String nickName
+) {
+}

--- a/src/test/java/com/happypill/application/service/user/UserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/user/UserServiceTest.java
@@ -11,6 +11,7 @@ import com.happypill.application.repository.happypilluser.HappypillUserRepositor
 import com.happypill.application.service.IntegrationTestSupport;
 import com.happypill.application.service.user.email.EmailVerificationRedisRepository;
 import com.happypill.application.service.user.request.EmailVerificationRequest;
+import com.happypill.application.service.user.request.UserNicknameRegisterRequest;
 import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
 import com.happypill.application.util.SnowflakeUtil;
 import net.datafaker.Faker;
@@ -43,6 +44,19 @@ class UserServiceTest extends IntegrationTestSupport {
         return userRepository.save(HappypillUser.ofSocial(
                 SnowflakeUtil.nextId(),
                 "nickname",
+                Provider.GOOGLE,
+                String.valueOf(SnowflakeUtil.nextId()),
+                email,
+                email,
+                Role.USER
+        ));
+    }
+
+    private HappypillUser generateTestUserWithoutNickname() {
+        String email = faker.internet().emailAddress();
+        return userRepository.save(HappypillUser.ofSocial(
+                SnowflakeUtil.nextId(),
+                null,
                 Provider.GOOGLE,
                 String.valueOf(SnowflakeUtil.nextId()),
                 email,
@@ -98,5 +112,32 @@ class UserServiceTest extends IntegrationTestSupport {
                 );
     }
 
+    @DisplayName("UserContext 의 id 가 존재하지 않는 유저일 경우 에러를 반환한다.")
+    @Test
+    void registerNickname_1() {
+        //given
+        HappypillUser user = generateTestUser();
+        UserContext userContext = SecurityUserContext.from(user.getId());
+        UserNicknameRegisterRequest request = new UserNicknameRegisterRequest("UserNickname");
 
+        //when //then
+        assertThatThrownBy(() -> service.registerNickname(userContext, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_NICKNAME_ALREADY_REGISTERED.getMessage());
+    }
+
+    @DisplayName("UserContext 의 id 가 존재하는 유저일 경우 유저의 닉네임이 등록된다.")
+    @Test
+    void registerNickname_2() {
+        //given
+        HappypillUser user = generateTestUserWithoutNickname();
+        UserContext userContext = SecurityUserContext.from(user.getId());
+        UserNicknameRegisterRequest request = new UserNicknameRegisterRequest("UserNickname");
+
+        //when
+        service.registerNickname(userContext, request);
+
+        //then
+        assertThat(user.getNickName().equals(request.nickName())).isTrue();
+    }
 }


### PR DESCRIPTION
# 티켓
HP-157

# 설명
- 로그인 시 회원이 닉네임을 입력하면 등록하는 API 구현
- request DTO 에 Null, NuLl, nulL 과 같은 null 문자열이 입력되는 걸 방지하는 커스텀 유효성 검사기 및 어노테이션 구현

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합테스트 및 postman 으로 유효성 검사

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 닉네임을 등록할 수 있는 API 엔드포인트가 추가되었습니다.
  * 닉네임 등록 시 유효성 검사 및 금지어(예: "null") 필터링이 적용됩니다.
  * 이미 닉네임이 등록된 경우 에러 메시지가 제공됩니다.

* **버그 수정**
  * 닉네임이 이미 등록된 회원에 대해 중복 등록을 방지하는 예외 처리가 추가되었습니다.

* **테스트**
  * 닉네임 등록 성공 및 실패(중복 등록) 시나리오에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->