### PR TITLE
HP-157 : 회원 닉네임 유효성 검증

### DIFF
--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -2,6 +2,8 @@ package com.happypill.application.entity;
 
 import com.happypill.application.entity.enums.Provider;
 import com.happypill.application.entity.enums.Role;
+import com.happypill.application.exception.custom.ExceptionCode;
+import com.happypill.application.exception.global.BusinessException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -47,7 +49,10 @@ public class HappypillUser extends BaseEntity<Long> {
         return new HappypillUser(id, nickName, provider, socialSub, loginEmail, notifyEmail, false, role);
     }
 
-    public void changeUser(String nickName) {
+    public void changeNickname(String nickName) {
+        if(this.nickName != null) {
+            throw new BusinessException(ExceptionCode.USER_NICKNAME_ALREADY_REGISTERED);
+        }
         this.nickName = nickName;
     }
 

--- a/src/main/java/com/happypill/application/entity/HappypillUser.java
+++ b/src/main/java/com/happypill/application/entity/HappypillUser.java
@@ -50,9 +50,6 @@ public class HappypillUser extends BaseEntity<Long> {
     }
 
     public void changeNickname(String nickName) {
-        if(this.nickName != null) {
-            throw new BusinessException(ExceptionCode.USER_NICKNAME_ALREADY_REGISTERED);
-        }
         this.nickName = nickName;
     }
 

--- a/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
+++ b/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
@@ -31,7 +31,8 @@ public enum ExceptionCode {
     CATEGORY_INFO_NOT_FOUND(NOT_FOUND, "해당 카테고리 정보를 찾을 수 없습니다"),
 
     USER_ALREADY_DELETED(BAD_REQUEST, "이미 삭제된 회원입니다."),
-    USER_NOT_DELETED(BAD_REQUEST, "삭제되지 않은 회원입니다.");
+    USER_NOT_DELETED(BAD_REQUEST, "삭제되지 않은 회원입니다."),
+    USER_NICKNAME_ALREADY_REGISTERED(BAD_REQUEST, "이미 닉네임이 등록된 회원입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
+++ b/src/main/java/com/happypill/application/exception/custom/ExceptionCode.java
@@ -31,8 +31,7 @@ public enum ExceptionCode {
     CATEGORY_INFO_NOT_FOUND(NOT_FOUND, "해당 카테고리 정보를 찾을 수 없습니다"),
 
     USER_ALREADY_DELETED(BAD_REQUEST, "이미 삭제된 회원입니다."),
-    USER_NOT_DELETED(BAD_REQUEST, "삭제되지 않은 회원입니다."),
-    USER_NICKNAME_ALREADY_REGISTERED(BAD_REQUEST, "이미 닉네임이 등록된 회원입니다.");
+    USER_NOT_DELETED(BAD_REQUEST, "삭제되지 않은 회원입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/happypill/application/service/admin/AdminUserService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminUserService.java
@@ -102,7 +102,7 @@ public class AdminUserService {
     private void updateNickname(HappypillUser user, AdminUserUpdateRequest request){
         String newNickname = request.nickName();
         if(newNickname != null && !newNickname.isBlank()){
-            user.changeUser(newNickname);
+            user.changeNickname(newNickname);
         }
     }
 

--- a/src/main/java/com/happypill/application/service/user/UserService.java
+++ b/src/main/java/com/happypill/application/service/user/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     public UserInfoResponse updateUser(UserContext userContext, UserUpdateRequest userUpdateRequest) {
         HappypillUser user = userRepository.findById(userContext.getId())
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
-        user.changeUser(userUpdateRequest.nickName());
+        user.changeNickname(userUpdateRequest.nickName());
         return UserInfoResponse.from(user);
     }
 

--- a/src/main/java/com/happypill/application/service/user/request/UserUpdateRequest.java
+++ b/src/main/java/com/happypill/application/service/user/request/UserUpdateRequest.java
@@ -1,9 +1,11 @@
 package com.happypill.application.service.user.request;
 
+import com.happypill.application.validation.ValidNickname;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserUpdateRequest(
         @NotBlank(message = "닉네임은 비어 있을 수 없습니다")
+        @ValidNickname
         String nickName
 ) {
 }

--- a/src/main/java/com/happypill/application/validation/ValidNickname.java
+++ b/src/main/java/com/happypill/application/validation/ValidNickname.java
@@ -1,0 +1,18 @@
+package com.happypill.application.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidNicknameValidator.class)
+public @interface ValidNickname {
+    String message() default "유효하지 않은 닉네임입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/happypill/application/validation/ValidNicknameValidator.java
+++ b/src/main/java/com/happypill/application/validation/ValidNicknameValidator.java
@@ -1,0 +1,17 @@
+package com.happypill.application.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidNicknameValidator implements ConstraintValidator<ValidNickname, String> {
+
+    private static final String FORBIDDEN_WORDS = "null";
+
+    @Override
+    public boolean isValid(String nickName, ConstraintValidatorContext constraintValidatorContext) {
+        if(nickName == null) {
+            return true; //@NotBlank 에서 검사하므로 여기에선 true 반환(@NotBlank 가 처리하도록 위임)
+        }
+        return !nickName.trim().equalsIgnoreCase(FORBIDDEN_WORDS);
+    }
+}

--- a/src/test/java/com/happypill/application/service/user/UserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/user/UserServiceTest.java
@@ -144,6 +144,6 @@ class UserServiceTest extends IntegrationTestSupport {
         UserInfoResponse response = service.updateUser(userContext, request);
 
         // then
-        assertThat(response.nickname().equals(request.nickName())).isTrue();
+assertThat(response.nickname()).isEqualTo(request.nickName());
     }
 }

--- a/src/test/java/com/happypill/application/service/user/UserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/user/UserServiceTest.java
@@ -132,21 +132,6 @@ class UserServiceTest extends IntegrationTestSupport {
 
     }
 
-    @DisplayName("이미 회원 닉네임이 등록되어 있으면 에러를 반환한다.")
-    @Test
-    void registerNickname_2() {
-        //given
-        HappypillUser user = generateTestUser();
-        UserContext userContext = SecurityUserContext.from(user.getId());
-        UserUpdateRequest request = new UserUpdateRequest("testNickname");
-
-        //when //then
-        assertThatThrownBy(() -> service.updateUser(userContext, request))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ExceptionCode.USER_NICKNAME_ALREADY_REGISTERED.getMessage());
-
-    }
-
     @DisplayName("유효한 닉네임 등록 시 유저의 닉네임이 변경된다.")
     @Test
     void registerNickname_3() {

--- a/src/test/java/com/happypill/application/service/user/UserServiceTest.java
+++ b/src/test/java/com/happypill/application/service/user/UserServiceTest.java
@@ -12,12 +12,19 @@ import com.happypill.application.service.IntegrationTestSupport;
 import com.happypill.application.service.user.email.EmailVerificationRedisRepository;
 import com.happypill.application.service.user.request.EmailVerificationRequest;
 import com.happypill.application.service.user.request.UserNotifyEmailUpdateRequest;
+import com.happypill.application.service.user.request.UserUpdateRequest;
+import com.happypill.application.service.user.response.UserInfoResponse;
 import com.happypill.application.util.SnowflakeUtil;
+import com.happypill.application.validation.ValidNicknameValidator;
+import jakarta.validation.ConstraintViolationException;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.time.Duration;
 
@@ -43,6 +50,19 @@ class UserServiceTest extends IntegrationTestSupport {
         return userRepository.save(HappypillUser.ofSocial(
                 SnowflakeUtil.nextId(),
                 "nickname",
+                Provider.GOOGLE,
+                String.valueOf(SnowflakeUtil.nextId()),
+                email,
+                email,
+                Role.USER
+        ));
+    }
+
+    private HappypillUser generateTestUserWithoutNickname() {
+        String email = faker.internet().emailAddress();
+        return userRepository.save(HappypillUser.ofSocial(
+                SnowflakeUtil.nextId(),
+                null,
                 Provider.GOOGLE,
                 String.valueOf(SnowflakeUtil.nextId()),
                 email,
@@ -98,5 +118,47 @@ class UserServiceTest extends IntegrationTestSupport {
                 );
     }
 
+    @DisplayName("UserContext 의 id 가 존재하지 않는 값이면 에러를 반환한다.")
+    @Test
+    void registerNickname_1() {
+        //given
+        UserContext userContext = SecurityUserContext.from(0L);
+        UserUpdateRequest request = new UserUpdateRequest("testNickname");
 
+        //when //then
+        assertThatThrownBy(() -> service.updateUser(userContext, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_NOT_FOUND.getMessage());
+
+    }
+
+    @DisplayName("이미 회원 닉네임이 등록되어 있으면 에러를 반환한다.")
+    @Test
+    void registerNickname_2() {
+        //given
+        HappypillUser user = generateTestUser();
+        UserContext userContext = SecurityUserContext.from(user.getId());
+        UserUpdateRequest request = new UserUpdateRequest("testNickname");
+
+        //when //then
+        assertThatThrownBy(() -> service.updateUser(userContext, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ExceptionCode.USER_NICKNAME_ALREADY_REGISTERED.getMessage());
+
+    }
+
+    @DisplayName("유효한 닉네임 등록 시 유저의 닉네임이 변경된다.")
+    @Test
+    void registerNickname_3() {
+        //given
+        HappypillUser user = generateTestUserWithoutNickname();
+        UserContext userContext = SecurityUserContext.from(user.getId());
+        UserUpdateRequest request = new UserUpdateRequest("testNickname");
+
+        //when
+        UserInfoResponse response = service.updateUser(userContext, request);
+
+        // then
+        assertThat(response.nickname().equals(request.nickName())).isTrue();
+    }
 }


### PR DESCRIPTION
# 티켓
HP-157

# 설명
- HappypillUser 엔티티의 changeUser 메서드명 변경(->changeNickname)
- 닉네임 등록 시 null 관련 문자열이 등록되지 않도록 유효성 검사기, 어노테이션 추가


## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
통합테스트 및 postman 으로 유효성 검증 로직 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 닉네임 유효성 검증이 추가되어, 특정 단어("null") 사용이 제한됩니다.
  * 닉네임이 이미 등록된 경우 중복 등록을 방지하는 오류 메시지가 제공됩니다.

* **버그 수정**
  * 닉네임 변경 시 기존 닉네임이 있을 경우 변경이 제한됩니다.

* **테스트**
  * 닉네임 등록 및 중복, 유효성 관련 테스트 케이스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->