### PR TITLE
HP-152 : [관리자] 구독 상품 관리 페이지 검색 기능

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminUserController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
@@ -55,6 +56,16 @@ public class AdminUserController {
                                                                       Locale locale){
         Pageable pageable = PageRequest.of(page - 1, size);
         return adminUserService.getAllSubscriptions(pageable, locale);
+    }
+
+    @Operation(summary = "구독 상품 검색", description = "회원들의 구독 상품들을 검색하기 위한 API")
+    @GetMapping("/subscriptions/search")
+    public CustomPage<AdminSubscriptionListResponse> searchSubscriptions(@RequestParam(value = "keyword") String keyword,
+                                                                         @RequestParam(value = "page") int page,
+                                                                         @RequestParam(value = "size") int size,
+                                                                         Locale locale) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return adminUserService.searchSubscriptions(pageable, keyword, locale);
     }
 
     @Operation(summary = "회원 계정 활성화", description = "회원 계정을 활성화하기 위한 API")

--- a/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryCustom.java
+++ b/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface SubscriptionRepositoryCustom {
     Page<AdminSubscriptionListResponse> findSubscriptionsByLanguageAndCompletionAndStatus(
             Language language, boolean isCompleted, OrderStatus orderStatus, Pageable pageable
     );
+
+    Page<AdminSubscriptionListResponse> searchSubscriptionsByLanguage(Pageable pageable, String keyword, Language language);
 }

--- a/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
@@ -75,10 +75,16 @@ public class SubscriptionRepositoryImpl implements SubscriptionRepositoryCustom{
 
         BooleanBuilder whereBuilder = new BooleanBuilder();
 
-        if(keyword != null && !keyword.isBlank()) {
-            whereBuilder.or(productInfo.name.containsIgnoreCase(keyword));
-            whereBuilder.or(happypillUser.notifyEmail.containsIgnoreCase(keyword));
-            whereBuilder.or(subscription.id.stringValue().containsIgnoreCase(keyword));
+        whereBuilder.and(subscription.isCompleted.eq(false));
+        whereBuilder.and(order.status.eq(OrderStatus.COMPLETED));
+
+        if (keyword != null && !keyword.isBlank()) {
+            BooleanBuilder keywordBuilder = new BooleanBuilder();
+            keywordBuilder.or(productInfo.name.containsIgnoreCase(keyword));
+            keywordBuilder.or(happypillUser.notifyEmail.containsIgnoreCase(keyword));
+            keywordBuilder.or(subscription.id.stringValue().containsIgnoreCase(keyword));
+
+            whereBuilder.and(keywordBuilder);
         }
 
         List<AdminSubscriptionListResponse> content = jpaQueryFactory
@@ -90,6 +96,7 @@ public class SubscriptionRepositoryImpl implements SubscriptionRepositoryCustom{
                 ))
                 .from(subscription)
                 .join(subscription.orderLine, orderLine)
+                .join(orderLine.order, order)
                 .join(orderLine.product, product)
                 .join(subscription.user, happypillUser)
                 .join(productInfo).on(productInfo.product.eq(product).and(productInfo.language.eq(language)))
@@ -102,6 +109,7 @@ public class SubscriptionRepositoryImpl implements SubscriptionRepositoryCustom{
                 .select(subscription.count())
                 .from(subscription)
                 .join(subscription.orderLine, orderLine)
+                .join(orderLine.order, order)
                 .join(orderLine.product, product)
                 .join(subscription.user, happypillUser)
                 .join(productInfo).on(productInfo.product.eq(product).and(productInfo.language.eq(language)))

--- a/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/subscription/SubscriptionRepositoryImpl.java
@@ -4,12 +4,15 @@ import com.happypill.application.entity.enums.Language;
 import com.happypill.application.entity.enums.OrderStatus;
 import com.happypill.application.service.admin.response.AdminSubscriptionListResponse;
 import com.happypill.application.service.admin.response.QAdminSubscriptionListResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -66,4 +69,46 @@ public class SubscriptionRepositoryImpl implements SubscriptionRepositoryCustom{
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
+
+    @Override
+    public Page<AdminSubscriptionListResponse> searchSubscriptionsByLanguage(Pageable pageable, String keyword, Language language) {
+
+        BooleanBuilder whereBuilder = new BooleanBuilder();
+
+        if(keyword != null && !keyword.isBlank()) {
+            whereBuilder.or(productInfo.name.containsIgnoreCase(keyword));
+            whereBuilder.or(happypillUser.notifyEmail.containsIgnoreCase(keyword));
+            whereBuilder.or(subscription.id.stringValue().containsIgnoreCase(keyword));
+        }
+
+        List<AdminSubscriptionListResponse> content = jpaQueryFactory
+                .select(new QAdminSubscriptionListResponse(
+                      productInfo.name,
+                      happypillUser.notifyEmail,
+                      subscription.id.stringValue(),
+                      subscription.nextDeliveryDate
+                ))
+                .from(subscription)
+                .join(subscription.orderLine, orderLine)
+                .join(orderLine.product, product)
+                .join(subscription.user, happypillUser)
+                .join(productInfo).on(productInfo.product.eq(product).and(productInfo.language.eq(language)))
+                .where(whereBuilder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory
+                .select(subscription.count())
+                .from(subscription)
+                .join(subscription.orderLine, orderLine)
+                .join(orderLine.product, product)
+                .join(subscription.user, happypillUser)
+                .join(productInfo).on(productInfo.product.eq(product).and(productInfo.language.eq(language)))
+                .where(whereBuilder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminUserService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminUserService.java
@@ -13,6 +13,7 @@ import com.happypill.application.service.admin.response.AdminSubscriptionListRes
 import com.happypill.application.service.admin.response.AdminUserDetailResponse;
 import com.happypill.application.service.admin.response.AdminUserListResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -97,6 +98,18 @@ public class AdminUserService {
 
         user.deactivate();
         return AdminUserDetailResponse.from(user);
+    }
+
+    public CustomPage<AdminSubscriptionListResponse> searchSubscriptions(Pageable pageable, String keyword, Locale locale) {
+        Language language = Language.parseLanguage(locale.getLanguage());
+
+        Page<AdminSubscriptionListResponse> responses = subscriptionRepository.searchSubscriptionsByLanguage(
+                pageable,
+                keyword,
+                language
+        );
+
+        return new CustomPage<>(responses);
     }
 
     private void updateNickname(HappypillUser user, AdminUserUpdateRequest request){


### PR DESCRIPTION
# 티켓
HP-152

# 설명
- 관리자 페이지에서 구독 상품을 검색하는 기능 추가

## 타입
- [ ] 버그
- [x] 작업
- [ ] 기능 향상

# 테스트 방법
postman 으로 조회 데이터 확인

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 구독 상품을 키워드와 언어별로 검색할 수 있는 새로운 검색 API가 추가되었습니다.  
  * 검색 결과는 페이지네이션되어 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->