### PR TITLE
HP-155: 관리자 카테고리 관리 페이지 검색기능 endpoint

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
@@ -40,7 +40,7 @@ public class AdminCategoryController {
 
     @Operation(summary = "카테고리 등록", description = "카테고리를 등록합니다.")
     @PostMapping
-//   ToDo @PreAuthorize("hasRole('ADMIN')")
+    //   ToDo @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> saveCategories(@RequestBody @Valid AdminCategoryRequest adminCategoryCreateRequestList) {
         adminCategoryService.saveCategories(adminCategoryCreateRequestList);
 
@@ -74,5 +74,15 @@ public class AdminCategoryController {
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public void deleteCategory(@PathVariable Long categoryId){
         adminCategoryService.deleteCategory(categoryId);
+    }
+
+    @Operation(summary = "카테고리 검색", description = "관리자가 특정 카테고리를 검색합니다")
+    @GetMapping("/search")
+    public CustomPage<AdminCategoryListResponse> searchCategory(@RequestParam(value = "keyword") String keyword,
+                                                                 @RequestParam(value = "page", defaultValue = "1") int page,
+                                                                 @RequestParam(value = "size", defaultValue = "5") int size,
+                                                                 Locale locale) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return adminCategoryService.searchCategory(pageable, locale, keyword);
     }
 }

--- a/src/main/java/com/happypill/application/repository/category/CategoryRepository.java
+++ b/src/main/java/com/happypill/application/repository/category/CategoryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Optional;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryRepositoryCustom{
 
     Optional<Category> findById(Long categoryId);
 

--- a/src/main/java/com/happypill/application/repository/category/CategoryRepositoryCustom.java
+++ b/src/main/java/com/happypill/application/repository/category/CategoryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.happypill.application.repository.category;
+
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.service.admin.response.AdminCategoryListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CategoryRepositoryCustom {
+    Page<AdminCategoryListResponse> searchCategoriesByKeyword(Pageable pageable, Language language, String keyword);
+}

--- a/src/main/java/com/happypill/application/repository/category/CategoryRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/category/CategoryRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.happypill.application.repository.category;
+
+import com.happypill.application.entity.enums.Language;
+import com.happypill.application.service.admin.response.AdminCategoryListResponse;
+import com.happypill.application.service.admin.response.QAdminCategoryListResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.happypill.application.entity.QCategory.category;
+import static com.happypill.application.entity.QCategoryInfo.categoryInfo;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryRepositoryImpl implements CategoryRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<AdminCategoryListResponse> searchCategoriesByKeyword(Pageable pageable, Language language, String keyword) {
+        BooleanBuilder keyBuilder = new BooleanBuilder();
+
+        if(keyword != null && !keyword.isBlank()) {
+            keyBuilder.or(categoryInfo.name.containsIgnoreCase(keyword));
+        }
+
+        List<AdminCategoryListResponse> content = jpaQueryFactory
+                .select(new QAdminCategoryListResponse(
+                        category.id,
+                        categoryInfo.name,
+                        categoryInfo.description,
+                        category.thumbnailUrl,
+                        category.bannerUrl
+                ))
+                .from(category)
+                .join(categoryInfo)
+                .on(
+                        categoryInfo.language.eq(language)
+                                .and(categoryInfo.category.id.eq(category.id))
+                )
+                .where(
+                        keyBuilder
+                )
+                .orderBy(category.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(content, pageable, content.size());
+    }
+}

--- a/src/main/java/com/happypill/application/repository/category/CategoryRepositoryImpl.java
+++ b/src/main/java/com/happypill/application/repository/category/CategoryRepositoryImpl.java
@@ -52,6 +52,19 @@ public class CategoryRepositoryImpl implements CategoryRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(content, pageable, content.size());
+        Long total = jpaQueryFactory
+                    .select(category.count())
+                    .from(category)
+                    .join(categoryInfo)
+                    .on(
+                        categoryInfo.language.eq(language)
+                        .and(categoryInfo.category.id.eq(category.id))
+                    )
+                    .where(
+                        keyBuilder
+                    )
+                    .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
@@ -140,4 +140,13 @@ public class AdminCategoryService {
         categoryInfoRepository.deleteAll(categoryInfos);
         categoryRepository.delete(category);
     }
+
+    public CustomPage<AdminCategoryListResponse> searchCategory(Pageable pageable, Locale locale, String keyword) {
+        Language language = Language.parseLanguage(locale.getLanguage());
+
+        Page<AdminCategoryListResponse> responses = categoryRepository.searchCategoriesByKeyword(pageable, language, keyword);
+
+        return new CustomPage<>(responses);
+    }
+
 }

--- a/src/main/java/com/happypill/application/service/admin/response/AdminCategoryListResponse.java
+++ b/src/main/java/com/happypill/application/service/admin/response/AdminCategoryListResponse.java
@@ -2,17 +2,40 @@ package com.happypill.application.service.admin.response;
 
 import com.happypill.application.entity.Category;
 import com.happypill.application.entity.CategoryInfo;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public record AdminCategoryListResponse(
-        String categoryId,
-        String name,
-        String description,
-        String thumbnailUrl,
-        String bannerImgUrl
-) {
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class AdminCategoryListResponse
+{
+    private String categoryId;
+    private String name;
+    private String description;
+    private String thumbnailUrl;
+    private String bannerImgUrl;
+
+    @QueryProjection
+    public AdminCategoryListResponse(
+            Long categoryId,
+            String name,
+            String description,
+            String thumbnailUrl,
+            String bannerImgUrl
+    ) {
+        this.categoryId = String.valueOf(categoryId);
+        this.name = name;
+        this.description = "";
+        this.thumbnailUrl = thumbnailUrl;
+        this.bannerImgUrl = "";
+    }
+
     public static AdminCategoryListResponse from(CategoryInfo categoryInfo, Category category){
         return new AdminCategoryListResponse(
-                category.getId().toString(),
+                category.getId(),
                 categoryInfo.getName(),
                 categoryInfo.getDescription(),
                 category.getThumbnailUrl(),

--- a/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/happypill/application/service/admin/AdminCategoryServiceTest.java
@@ -68,7 +68,7 @@ class AdminCategoryServiceTest {
 
         //then
         assertThat(result.contents())
-                .extracting(AdminCategoryListResponse::name)
+                .extracting(AdminCategoryListResponse::getName)
                 .anyMatch(name -> name.contains("KO"));
     }
 


### PR DESCRIPTION
# 티켓
HP-155

# 설명
카테고리페이지에서 이름이 검색 키워드와 매칭되는 결과를 받을 수 있는 검색기능 추가

## 타입
- [ ] 버그
- [X] 작업
- [ ] 기능 향상

# 테스트 방법
postman 으로 테스트

# 체크리스트
- [X] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [X] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [X] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 카테고리를 키워드로 검색할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 검색 결과는 페이지네이션이 지원됩니다.

* **버그 수정**
  * 일부 카테고리 목록 응답 객체의 내부 동작이 개선되었습니다.

* **테스트**
  * 카테고리 이름 추출 방식이 getter 메서드 사용으로 변경되어 테스트 코드가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->