### PR TITLE
HP-166: 관리자 카테고리조회시 카테고리별 등록된 상품 개수 추가

### DIFF
--- a/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
+++ b/src/main/java/com/happypill/api/controller/admin/AdminCategoryController.java
@@ -32,7 +32,7 @@ public class AdminCategoryController {
     @GetMapping
     //TODO : 추가 예정 @PreAuthorize("hasRole('ADMIN')")
     public CustomPage<AdminCategoryListResponse> getCategories(@RequestParam(value = "page", defaultValue = "1") int page,
-                                                               @RequestParam(value = "size", defaultValue = "5") int size,
+                                                               @RequestParam(value = "size", defaultValue = "10") int size,
                                                                Locale locale) {
         Pageable pageable = PageRequest.of(page - 1, size);
         return adminCategoryService.getAllCategories(pageable, locale);

--- a/src/main/java/com/happypill/application/repository/category/CategoryRepository.java
+++ b/src/main/java/com/happypill/application/repository/category/CategoryRepository.java
@@ -1,8 +1,10 @@
 package com.happypill.application.repository.category;
 
 import com.happypill.application.entity.Category;
+import com.happypill.application.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +18,11 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
             FROM Category c
             """)
     List<Category> findAllCategories();
+
+    @Query("""
+            SELECT p
+            FROM Product p
+            WHERE p.category.id = :categoryId
+            """)
+    List<Product> findAllProductsInTheCategory(@Param("categoryId")Long categoryId);
 }

--- a/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
+++ b/src/main/java/com/happypill/application/service/admin/AdminCategoryService.java
@@ -45,7 +45,8 @@ public class AdminCategoryService {
 
         Page<AdminCategoryListResponse> responsePage = categoryInfos.map(categoryInfo -> {
                     Category category = categoryInfo.getCategory();
-                    return AdminCategoryListResponse.from(categoryInfo, category);
+                    int numOfProducts = categoryRepository.findAllProductsInTheCategory(category.getId()).size();
+                    return AdminCategoryListResponse.from(categoryInfo, category, numOfProducts);
                 }
         );
         return new CustomPage<>(responsePage);

--- a/src/main/java/com/happypill/application/service/admin/response/AdminCategoryListResponse.java
+++ b/src/main/java/com/happypill/application/service/admin/response/AdminCategoryListResponse.java
@@ -8,15 +8,17 @@ public record AdminCategoryListResponse(
         String name,
         String description,
         String thumbnailUrl,
-        String bannerImgUrl
+        String bannerImgUrl,
+        int numOfProducts
 ) {
-    public static AdminCategoryListResponse from(CategoryInfo categoryInfo, Category category){
+    public static AdminCategoryListResponse from(CategoryInfo categoryInfo, Category category, int numOfProducts){
         return new AdminCategoryListResponse(
                 category.getId().toString(),
                 categoryInfo.getName(),
                 categoryInfo.getDescription(),
                 category.getThumbnailUrl(),
-                category.getBannerUrl()
+                category.getBannerUrl(),
+                numOfProducts
         );
     }
 }


### PR DESCRIPTION
# 티켓
HP-166

# 설명
관리자 카테고리조회시 카테고리별 등록된 상품 개수 추가.

## 타입
- [ ] 버그
- [X] 작업
- [ ] 기능 향상

# 테스트 방법
Postman 으로 테스트

# 체크리스트
- [X] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [X] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [X] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카테고리 목록에 각 카테고리별 상품 개수 정보가 추가되었습니다.

* **기능 개선**
  * 카테고리 목록 조회 시 한 페이지에 표시되는 기본 항목 수가 5개에서 10개로 증가하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->