### PR TITLE
fix : 카테고리 검색 리팩토링

### DIFF
--- a/src/main/java/com/happypill/application/repository/category/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/com/happypill/application/repository/category/CategoryRepositoryCustomImpl.java
@@ -27,7 +27,7 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
     public Page<AdminCategoryListResponse> searchCategoriesByKeyword(Pageable pageable, Language language, String keyword) {
         BooleanBuilder keyBuilder = new BooleanBuilder();
 
-        if(keyword != null && !keyword.isBlank()) {
+        if (keyword != null && !keyword.isBlank()) {
             keyBuilder.or(categoryInfo.name.containsIgnoreCase(keyword));
         }
 
@@ -38,7 +38,7 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
                         categoryInfo.description,
                         category.thumbnailUrl,
                         category.bannerUrl,
-                        product.count().intValue()
+                        product.count().intValue() // 카테고리별 상품 개수
                 ))
                 .from(category)
                 .join(categoryInfo)
@@ -46,12 +46,15 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
                         categoryInfo.language.eq(language)
                                 .and(categoryInfo.category.id.eq(category.id))
                 )
-                .join(product)
-                .on(
-                        product.category.id.eq(category.id)
-                )
-                .where(
-                        keyBuilder
+                .leftJoin(product)
+                .on(product.category.id.eq(category.id))
+                .where(keyBuilder)
+                .groupBy(
+                        category.id,
+                        categoryInfo.name,
+                        categoryInfo.description,
+                        category.thumbnailUrl,
+                        category.bannerUrl
                 )
                 .orderBy(category.id.desc())
                 .offset(pageable.getOffset())
@@ -59,18 +62,17 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
                 .fetch();
 
         Long total = jpaQueryFactory
-                    .select(category.count())
-                    .from(category)
-                    .join(categoryInfo)
-                    .on(
+                .select(category.id.countDistinct())
+                .from(category)
+                .join(categoryInfo)
+                .on(
                         categoryInfo.language.eq(language)
-                        .and(categoryInfo.category.id.eq(category.id))
-                    )
-                    .where(
-                        keyBuilder
-                    )
-                    .fetchOne();
+                                .and(categoryInfo.category.id.eq(category.id))
+                )
+                .where(keyBuilder)
+                .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
+
 }

--- a/src/main/java/com/happypill/application/util/DataInitialiser.java
+++ b/src/main/java/com/happypill/application/util/DataInitialiser.java
@@ -315,7 +315,7 @@ public class DataInitialiser implements ApplicationRunner {
         productInfoRepository.saveAll(productInfoList);
         productPriceRepository.saveAll(productPriceList);
 
-        generateDevData();
+        //generateDevData();
 
         createBestProduct(productList.subList(0, 10));
     }


### PR DESCRIPTION
# 티켓
HP-181

# 설명
관리자 페이지에서 카테고리 검색 부분 에러로 인한 리팩토링

## 타입
- [x] 버그
- [ ] 작업
- [ ] 기능 향상

# 테스트 방법
테스트 없음

# 체크리스트
- [x] 작성한 코드가 새로운 에러를 만들지 않았습니다
- [x] 코드가 코드 컨벤션에 모두 만족하는지 확인하였습니다
- [x] 작성한 코드에 관한 unit test를 작성하였고 모든 테스트를 통과하였습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 카테고리 목록에서 상품 유무와 관계없이 모든 카테고리가 노출되며, 각 카테고리의 상품 개수가 함께 표시됩니다.
  * 페이지네이션의 총 개수가 중복 없이 정확히 계산되어 목록과 일치합니다.
  * 검색어 및 언어 필터 사용 시에도 목록과 총 개수가 동일한 기준으로 집계됩니다.
* Chores
  * 개발용 더미 데이터 자동 시딩을 비활성화했습니다(운영 사용자에게는 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->